### PR TITLE
feat(board-recognition): add moku AI detection backend with RT-DETR

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "kaya",
@@ -105,6 +104,9 @@
     "packages/board-recognition": {
       "name": "@kaya/board-recognition",
       "version": "0.2.5-dev",
+      "dependencies": {
+        "onnxruntime-web": "^1.24.2",
+      },
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.6.0",

--- a/packages/board-recognition/package.json
+++ b/packages/board-recognition/package.json
@@ -11,7 +11,9 @@
     "type-check": "tsc --noEmit",
     "test": "bun test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "onnxruntime-web": "^1.24.2"
+  },
   "devDependencies": {
     "@types/bun": "latest",
     "typescript": "^5.6.0"

--- a/packages/board-recognition/src/index.ts
+++ b/packages/board-recognition/src/index.ts
@@ -12,6 +12,7 @@ export type {
   RecognitionOptions,
   RecognitionResult,
   StoneColor,
+  MokuRawDetection,
 } from './types';
 
 import type {
@@ -28,10 +29,12 @@ import { classifyIntersections, classifyWithHints } from './stones';
 import { buildSGF } from './sgf';
 
 export { orderCorners, estimateGridInWarped } from './corners';
-export { warpPerspective } from './perspective';
+export { warpPerspective, computeHomography, applyHomography } from './perspective';
 export { classifyIntersections, classifyWithHints } from './stones';
 export { buildSGF } from './sgf';
 export { toGrayscale } from './image';
+export { MokuDetector, mapStonesToGrid, expandCorners } from './moku-detector';
+export type { MokuDetectorConfig, MokuDetectOptions } from './moku-detector';
 
 // ============================================================================
 // Main entry point

--- a/packages/board-recognition/src/moku-detector.ts
+++ b/packages/board-recognition/src/moku-detector.ts
@@ -1,0 +1,402 @@
+// ============================================================================
+// Moku Detector – ONNX-based Go board detection using RT-DETR
+//
+// Alternative detection backend using a trained object detection model
+// (kaya-go/moku-v1) to detect board corners and stones directly.
+//
+// Uses dynamic import for onnxruntime-web to avoid loading the ONNX runtime
+// bundle unless the moku detector is actually needed.
+// ============================================================================
+
+import type {
+  RawImage,
+  Point,
+  BoardCorners,
+  DetectedStone,
+  MokuRawDetection,
+  RecognitionResult,
+} from './types';
+import { orderCorners, imageCorners } from './corners';
+import { computeHomography, applyHomography } from './perspective';
+import { warpPerspective } from './perspective';
+import { buildSGF } from './sgf';
+
+// Lazy-loaded ONNX runtime module
+let _ort: typeof import('onnxruntime-web') | null = null;
+
+async function getOrt() {
+  if (!_ort) {
+    _ort = await import('onnxruntime-web');
+  }
+  return _ort;
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const DEFAULT_MODEL_URL = 'https://huggingface.co/kaya-go/moku-v1/resolve/main/model.onnx';
+
+const INPUT_SIZE = 640;
+const NUM_QUERIES = 300;
+const NUM_CLASSES = 3;
+
+// Class IDs (must match training categories)
+const CLASS_BLACK_STONE = 0;
+const CLASS_WHITE_STONE = 1;
+const CLASS_BOARD_CORNER = 2;
+
+const DEFAULT_THRESHOLD = 0.05;
+const WARP_OUTPUT_SIZE = 800;
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface MokuDetectorConfig {
+  /** URL to the ONNX model (default: HuggingFace kaya-go/moku-v1) */
+  modelUrl?: string;
+  /** Path to ONNX Runtime WASM files (default: '/wasm/') */
+  wasmPath?: string;
+}
+
+export interface MokuDetectOptions {
+  boardSize: 9 | 13 | 19;
+  /** Confidence threshold for detections (default: 0.5) */
+  threshold?: number;
+  /** Output warped image size (default: 800) */
+  outputSize?: number;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function sigmoid(x: number): number {
+  return 1 / (1 + Math.exp(-x));
+}
+
+/**
+ * Return image-edge corners inset by a fraction of the smaller dimension.
+ * Used as a fallback when corner detection fails or produces degenerate results.
+ */
+function insetImageCorners(w: number, h: number, fraction: number): BoardCorners {
+  const m = Math.min(w, h) * fraction;
+  return [
+    [m, m],
+    [w - 1 - m, m],
+    [w - 1 - m, h - 1 - m],
+    [m, h - 1 - m],
+  ];
+}
+
+/**
+ * Check whether 4 corners are degenerate (e.g. all clustered at the same spot).
+ * Returns true when the bounding box of the corners covers less than `minFraction`
+ * of the image area.
+ */
+function areCornersDegenerate(
+  corners: BoardCorners,
+  imgWidth: number,
+  imgHeight: number,
+  minFraction = 0.02
+): boolean {
+  const xs = corners.map(c => c[0]);
+  const ys = corners.map(c => c[1]);
+  const bboxArea = (Math.max(...xs) - Math.min(...xs)) * (Math.max(...ys) - Math.min(...ys));
+  return bboxArea < imgWidth * imgHeight * minFraction;
+}
+
+/**
+ * Expand board corners outward by a relative margin so the warped preview
+ * includes some area around the board edges.
+ */
+export function expandCorners(
+  corners: BoardCorners,
+  imgWidth: number,
+  imgHeight: number,
+  margin: number // fraction, e.g. 0.05 = 5%
+): BoardCorners {
+  // Compute centroid
+  const cx = (corners[0][0] + corners[1][0] + corners[2][0] + corners[3][0]) / 4;
+  const cy = (corners[0][1] + corners[1][1] + corners[2][1] + corners[3][1]) / 4;
+
+  return corners.map(([px, py]) => {
+    const dx = px - cx;
+    const dy = py - cy;
+    return [
+      Math.max(0, Math.min(imgWidth - 1, px + dx * margin)),
+      Math.max(0, Math.min(imgHeight - 1, py + dy * margin)),
+    ] as Point;
+  }) as BoardCorners;
+}
+
+// ── MokuDetector class ───────────────────────────────────────────────────────
+
+export class MokuDetector {
+  private session: import('onnxruntime-web').InferenceSession | null = null;
+  private config: MokuDetectorConfig;
+
+  constructor(config: MokuDetectorConfig = {}) {
+    this.config = config;
+  }
+
+  /** Load the ONNX model. Must be called before `detect()`. */
+  async init(): Promise<void> {
+    const ort = await getOrt();
+    const modelUrl = this.config.modelUrl ?? DEFAULT_MODEL_URL;
+
+    // Configure WASM paths so the runtime finds its .wasm files
+    ort.env.wasm.wasmPaths = this.config.wasmPath ?? '/wasm/';
+    ort.env.wasm.numThreads = 1;
+
+    // Fetch the model ourselves for better error handling
+    const response = await fetch(modelUrl);
+    if (!response.ok) {
+      throw new Error(`Failed to download model: ${response.status} ${response.statusText}`);
+    }
+    const modelBuffer = await response.arrayBuffer();
+
+    this.session = await ort.InferenceSession.create(modelBuffer, {
+      executionProviders: ['wasm'],
+      graphOptimizationLevel: 'all',
+    });
+  }
+
+  /** Whether the model is loaded and ready for inference. */
+  get ready(): boolean {
+    return this.session !== null;
+  }
+
+  /**
+   * Run object detection on a raw RGBA image and return a RecognitionResult
+   * compatible with the existing board-recognition pipeline.
+   */
+  async detect(img: RawImage, options: MokuDetectOptions): Promise<RecognitionResult> {
+    if (!this.session) {
+      throw new Error('MokuDetector not initialized – call init() first');
+    }
+
+    const threshold = options.threshold ?? DEFAULT_THRESHOLD;
+    const outputSize = options.outputSize ?? WARP_OUTPUT_SIZE;
+
+    // 1. Preprocess image → (1, 3, 640, 640) normalized tensor
+    const inputTensor = preprocess(img);
+
+    // 2. Run inference
+    const feeds = { pixel_values: inputTensor };
+    const results = await this.session.run(feeds);
+    const logits = results.logits.data as Float32Array; // (1, 300, 3)
+    const predBoxes = results.pred_boxes.data as Float32Array; // (1, 300, 4)
+
+    // 3. Postprocess → RecognitionResult
+    return postprocess(logits, predBoxes, img, options.boardSize, threshold, outputSize);
+  }
+
+  /** Release the ONNX session and free resources. */
+  dispose(): void {
+    this.session?.release();
+    this.session = null;
+  }
+}
+
+// ── Preprocessing ────────────────────────────────────────────────────────────
+
+/**
+ * Resize RGBA image to 640×640 and normalize with ImageNet stats.
+ * Returns a CHW float32 tensor ready for RT-DETR inference.
+ */
+function preprocess(img: RawImage) {
+  const { data, width, height } = img;
+  const buf = new Float32Array(3 * INPUT_SIZE * INPUT_SIZE);
+
+  for (let y = 0; y < INPUT_SIZE; y++) {
+    for (let x = 0; x < INPUT_SIZE; x++) {
+      // Map output pixel to source coords (bilinear interpolation)
+      const srcX = (x + 0.5) * (width / INPUT_SIZE) - 0.5;
+      const srcY = (y + 0.5) * (height / INPUT_SIZE) - 0.5;
+
+      const x0 = Math.max(0, Math.floor(srcX));
+      const y0 = Math.max(0, Math.floor(srcY));
+      const x1 = Math.min(x0 + 1, width - 1);
+      const y1 = Math.min(y0 + 1, height - 1);
+      const fx = srcX - Math.floor(srcX);
+      const fy = srcY - Math.floor(srcY);
+
+      const i00 = (y0 * width + x0) * 4;
+      const i10 = (y0 * width + x1) * 4;
+      const i01 = (y1 * width + x0) * 4;
+      const i11 = (y1 * width + x1) * 4;
+
+      for (let c = 0; c < 3; c++) {
+        const val =
+          data[i00 + c] * (1 - fx) * (1 - fy) +
+          data[i10 + c] * fx * (1 - fy) +
+          data[i01 + c] * (1 - fx) * fy +
+          data[i11 + c] * fx * fy;
+
+        // Rescale [0, 255] → [0, 1] only (model trained with do_normalize=false)
+        const normalized = val / 255;
+
+        // CHW layout: channel * H * W + y * W + x
+        buf[c * INPUT_SIZE * INPUT_SIZE + y * INPUT_SIZE + x] = normalized;
+      }
+    }
+  }
+
+  return new _ort!.Tensor('float32', buf, [1, 3, INPUT_SIZE, INPUT_SIZE]);
+}
+
+// ── Postprocessing ───────────────────────────────────────────────────────────
+
+function postprocess(
+  logits: Float32Array,
+  predBoxes: Float32Array,
+  origImg: RawImage,
+  boardSize: 9 | 13 | 19,
+  threshold: number,
+  outputSize: number
+): RecognitionResult {
+  const stones: MokuRawDetection[] = [];
+  const cornerCandidates: MokuRawDetection[] = [];
+
+  // Decode all 300 queries – each query represents ONE object.
+  // Use argmax to pick the best class per query (RT-DETR convention).
+  for (let q = 0; q < NUM_QUERIES; q++) {
+    const logitBase = q * NUM_CLASSES;
+    const boxBase = q * 4;
+
+    // Find the class with the highest score for this query
+    let bestClass = 0;
+    let bestScore = -Infinity;
+    for (let c = 0; c < NUM_CLASSES; c++) {
+      const s = sigmoid(logits[logitBase + c]);
+      if (s > bestScore) {
+        bestScore = s;
+        bestClass = c;
+      }
+    }
+
+    if (bestScore < threshold) continue;
+
+    // pred_boxes: [cx, cy, w, h] normalized to [0, 1]
+    const cx = predBoxes[boxBase] * origImg.width;
+    const cy = predBoxes[boxBase + 1] * origImg.height;
+
+    const det: MokuRawDetection = { cx, cy, classId: bestClass, score: bestScore };
+    if (bestClass === CLASS_BOARD_CORNER) {
+      cornerCandidates.push(det);
+    } else {
+      stones.push(det);
+    }
+  }
+
+  // Sort corners by confidence, take top 4
+  cornerCandidates.sort((a, b) => b.score - a.score);
+
+  if (cornerCandidates.length < 4) {
+    // Fallback: no corners detected → use image bounds with margin
+    const corners = insetImageCorners(origImg.width, origImg.height, 0.05);
+    const warped = warpPerspective(origImg, corners, outputSize);
+    return {
+      boardSize,
+      stones: [],
+      corners,
+      cornersDetected: false,
+      sgf: buildSGF(boardSize, []),
+      warpedImage: warped,
+    };
+  }
+
+  // Order corners clockwise: TL → TR → BR → BL
+  const top4Points: Point[] = cornerCandidates.slice(0, 4).map(d => [d.cx, d.cy] as Point);
+  let corners = orderCorners(top4Points);
+
+  // If the 4 detected corners are degenerate (all clustered together),
+  // fall back to image-edge corners with margin.
+  if (areCornersDegenerate(corners, origImg.width, origImg.height)) {
+    corners = insetImageCorners(origImg.width, origImg.height, 0.05);
+  }
+
+  // Warp for preview – map board corners to an inset region so there is
+  // a visible margin around the board edges regardless of image bounds.
+  const WARP_MARGIN = 0.08; // 8% of output size
+  const m = Math.round(outputSize * WARP_MARGIN);
+  const insetDst: [Point, Point, Point, Point] = [
+    [m, m],
+    [outputSize - 1 - m, m],
+    [outputSize - 1 - m, outputSize - 1 - m],
+    [m, outputSize - 1 - m],
+  ];
+  const warped = warpPerspective(origImg, corners, outputSize, insetDst);
+
+  // The grid corners in warped space are exactly the inset destination corners.
+  const estimatedGrid: BoardCorners = insetDst;
+
+  // Map detected stone centers to grid intersections via homography
+  const detectedStones = mapStonesToGrid(stones, corners, boardSize);
+
+  // Preserve raw detections so corners can be re-mapped without re-running inference
+  const rawDetections: MokuRawDetection[] = stones.map(d => ({
+    cx: d.cx,
+    cy: d.cy,
+    classId: d.classId,
+    score: d.score,
+  }));
+
+  return {
+    boardSize,
+    stones: detectedStones,
+    corners,
+    cornersDetected: true,
+    sgf: buildSGF(boardSize, detectedStones),
+    warpedImage: warped,
+    estimatedGridCorners: estimatedGrid,
+    mokuRawDetections: rawDetections,
+  };
+}
+
+/**
+ * Map detected stone center coordinates to discrete board intersections
+ * using a perspective homography from the 4 detected board corners.
+ */
+export function mapStonesToGrid(
+  stones: MokuRawDetection[],
+  corners: BoardCorners,
+  boardSize: number
+): DetectedStone[] {
+  // Destination: unit square [0, 1] × [0, 1]
+  const dst: [Point, Point, Point, Point] = [
+    [0, 0],
+    [1, 0],
+    [1, 1],
+    [0, 1],
+  ];
+
+  const H = computeHomography(corners, dst);
+  if (!H) return [];
+
+  const result: DetectedStone[] = [];
+  const occupied = new Set<string>();
+
+  // Sort by score descending so higher confidence wins ties
+  const sorted = [...stones].sort((a, b) => b.score - a.score);
+
+  for (const det of sorted) {
+    const [rx, ry] = applyHomography(H, det.cx, det.cy);
+
+    // Snap to nearest grid intersection
+    const col = Math.round(rx * (boardSize - 1));
+    const row = Math.round(ry * (boardSize - 1));
+
+    // Discard out-of-bounds
+    if (col < 0 || col >= boardSize || row < 0 || row >= boardSize) continue;
+
+    // Discard duplicate grid positions (higher confidence already placed)
+    const key = `${col},${row}`;
+    if (occupied.has(key)) continue;
+    occupied.add(key);
+
+    result.push({
+      x: col,
+      y: row,
+      color: det.classId === CLASS_BLACK_STONE ? 'black' : 'white',
+    });
+  }
+
+  return result;
+}

--- a/packages/board-recognition/src/perspective.ts
+++ b/packages/board-recognition/src/perspective.ts
@@ -98,13 +98,20 @@ export function invertMatrix3(m: number[]): number[] | null {
 // ============================================================================
 
 /**
- * Warp the input image so that `corners` [TL, TR, BR, BL] maps to a
- * square of size `outSize × outSize`.
+ * Warp the input image so that `corners` [TL, TR, BR, BL] maps to
+ * `dstCorners` within a square of size `outSize × outSize`.
+ *
+ * When `dstCorners` is omitted the corners map to the full output square.
  */
-export function warpPerspective(img: RawImage, corners: BoardCorners, outSize: number): RawImage {
+export function warpPerspective(
+  img: RawImage,
+  corners: BoardCorners,
+  outSize: number,
+  dstCorners?: [Point, Point, Point, Point]
+): RawImage {
   const { data, width, height } = img;
 
-  const dst: [Point, Point, Point, Point] = [
+  const dst: [Point, Point, Point, Point] = dstCorners ?? [
     [0, 0],
     [outSize - 1, 0],
     [outSize - 1, outSize - 1],

--- a/packages/board-recognition/src/types.ts
+++ b/packages/board-recognition/src/types.ts
@@ -51,6 +51,14 @@ export interface RecognitionOptions {
   gridCorners?: BoardCorners;
 }
 
+/** Raw moku detection in original image coordinates (for re-mapping on corner change) */
+export interface MokuRawDetection {
+  cx: number;
+  cy: number;
+  classId: number;
+  score: number;
+}
+
 /** Full recognition result */
 export interface RecognitionResult {
   boardSize: number;
@@ -61,4 +69,6 @@ export interface RecognitionResult {
   warpedImage: RawImage; // for preview
   /** Estimated grid corners within the warped image (inset from board boundary). */
   estimatedGridCorners?: BoardCorners;
+  /** Raw moku detections in image coords (only set by moku backend, for corner re-mapping). */
+  mokuRawDetections?: MokuRawDetection[];
 }

--- a/packages/ui/src/components/dialogs/BoardRecognitionDialog.css
+++ b/packages/ui/src/components/dialogs/BoardRecognitionDialog.css
@@ -92,6 +92,52 @@
   color: var(--accent, #4a9eff);
 }
 
+.brd-size-sep {
+  width: 1px;
+  height: 20px;
+  background: var(--border-color, #444);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+.brd-moku-status {
+  font-size: 0.8rem;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.brd-moku-loading {
+  color: var(--text-secondary, #888);
+  animation: brd-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes brd-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+.brd-threshold-label {
+  margin-left: 4px;
+}
+
+.brd-threshold-slider {
+  width: 100px;
+  accent-color: var(--accent, #4a9eff);
+  cursor: pointer;
+}
+
+.brd-threshold-value {
+  font-size: 0.8rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-secondary, #888);
+  min-width: 2.5em;
+}
+
 /* Body */
 .brd-body {
   display: grid;

--- a/packages/ui/src/components/dialogs/BoardRecognitionDialog.tsx
+++ b/packages/ui/src/components/dialogs/BoardRecognitionDialog.tsx
@@ -19,7 +19,7 @@ import type {
   RawImage,
   StoneColor,
 } from '@kaya/board-recognition';
-import { orderCorners } from '@kaya/board-recognition';
+import { orderCorners, buildSGF, warpPerspective, mapStonesToGrid } from '@kaya/board-recognition';
 import { BoardRecognitionWorker } from '../../workers/BoardRecognitionWorker';
 import './BoardRecognitionDialog.css';
 
@@ -130,6 +130,12 @@ export const BoardRecognitionDialog: React.FC<Props> = ({ file, onImport, onClos
   const [gridClicks, setGridClicks] = useState<Point[]>([]);
   const [settingGrid, setSettingGrid] = useState(false);
 
+  // Detection backend state
+  const [detectionBackend, setDetectionBackend] = useState<'classic' | 'moku'>('moku');
+  const [mokuThreshold, setMokuThreshold] = useState(0.05);
+  const [mokuReady, setMokuReady] = useState(false);
+  const [mokuLoading, setMokuLoading] = useState(false);
+
   // ── Refs ───────────────────────────────────────────────
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -141,9 +147,12 @@ export const BoardRecognitionDialog: React.FC<Props> = ({ file, onImport, onClos
   const dragOffsetRef = useRef<[number, number]>([0, 0]);
   const workerRef = useRef<BoardRecognitionWorker | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const warpDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reclassifySeqRef = useRef(0);
   const boardSizeRef = useRef<BoardSize | null>(null);
   const gridCornersRef = useRef<BoardCorners | null>(null);
+  const mokuThresholdRef = useRef(0.05);
+  const thresholdDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // ── Worker lifecycle ──────────────────────────────────
   useEffect(() => {
@@ -152,6 +161,7 @@ export const BoardRecognitionDialog: React.FC<Props> = ({ file, onImport, onClos
     return () => {
       w.dispose();
       workerRef.current = null;
+      if (thresholdDebounceRef.current) clearTimeout(thresholdDebounceRef.current);
     };
   }, []);
 
@@ -165,6 +175,33 @@ export const BoardRecognitionDialog: React.FC<Props> = ({ file, onImport, onClos
   useEffect(() => {
     gridCornersRef.current = gridCorners;
   }, [gridCorners]);
+  useEffect(() => {
+    mokuThresholdRef.current = mokuThreshold;
+  }, [mokuThreshold]);
+
+  // ── Init moku detector when backend switches ─────────
+  useEffect(() => {
+    if (detectionBackend !== 'moku' || !workerRef.current || mokuReady) return;
+    let cancelled = false;
+    setMokuLoading(true);
+    workerRef.current
+      .mokuInit()
+      .then(() => {
+        if (!cancelled) {
+          setMokuReady(true);
+          setMokuLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setMokuLoading(false);
+          setLoadError(t('boardRecognition.mokuError'));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [detectionBackend, mokuReady, t]);
 
   // ── Load & downscale image ────────────────────────────
   useEffect(() => {
@@ -193,6 +230,8 @@ export const BoardRecognitionDialog: React.FC<Props> = ({ file, onImport, onClos
   // ── Run recognition when boardSize + rawImage ready ───
   useEffect(() => {
     if (!rawImage || !boardSize || !workerRef.current) return;
+    if (detectionBackend === 'moku' && !mokuReady) return;
+
     let cancelled = false;
     setAnalyzing(true);
     setResult(null);
@@ -200,14 +239,22 @@ export const BoardRecognitionDialog: React.FC<Props> = ({ file, onImport, onClos
     setHints([]);
     setCalibrationMode(null);
 
-    workerRef.current
-      .recognizeBoard(rawImage.data, rawImage.width, rawImage.height, { boardSize })
+    const promise =
+      detectionBackend === 'moku'
+        ? workerRef.current.mokuDetect(rawImage.data, rawImage.width, rawImage.height, {
+            boardSize,
+            threshold: mokuThresholdRef.current,
+          })
+        : workerRef.current.recognizeBoard(rawImage.data, rawImage.width, rawImage.height, {
+            boardSize,
+          });
+
+    promise
       .then(r => {
         if (cancelled) return;
         setCorners(r.corners);
         setResult(r);
         setWarpedURL(rawImageToDataURL(r.warpedImage));
-        // Auto-set estimated grid corners so the grid overlay is correctly inset
         if (r.estimatedGridCorners) {
           setGridCorners(r.estimatedGridCorners);
           gridCornersRef.current = r.estimatedGridCorners;
@@ -223,16 +270,112 @@ export const BoardRecognitionDialog: React.FC<Props> = ({ file, onImport, onClos
     return () => {
       cancelled = true;
     };
-  }, [rawImage, boardSize, t]);
+  }, [rawImage, boardSize, detectionBackend, mokuReady, t]);
+
+  // ── Debounced moku threshold re-detection ────────────
+  const handleMokuThresholdChange = useCallback(
+    (newThreshold: number) => {
+      setMokuThreshold(newThreshold);
+      mokuThresholdRef.current = newThreshold;
+
+      if (
+        detectionBackend !== 'moku' ||
+        !mokuReady ||
+        !rawImage ||
+        !boardSize ||
+        !workerRef.current
+      )
+        return;
+
+      if (thresholdDebounceRef.current) clearTimeout(thresholdDebounceRef.current);
+
+      const seq = ++reclassifySeqRef.current;
+      thresholdDebounceRef.current = setTimeout(() => {
+        if (!workerRef.current) return;
+        setAnalyzing(true);
+
+        workerRef.current
+          .mokuDetect(rawImage.data, rawImage.width, rawImage.height, {
+            boardSize,
+            threshold: newThreshold,
+          })
+          .then(r => {
+            if (reclassifySeqRef.current !== seq) return;
+            setCorners(r.corners);
+            setResult(r);
+            setWarpedURL(rawImageToDataURL(r.warpedImage));
+            if (r.estimatedGridCorners) {
+              setGridCorners(r.estimatedGridCorners);
+              gridCornersRef.current = r.estimatedGridCorners;
+            }
+            setHints([]);
+          })
+          .catch(() => {
+            /* ignore stale/cancelled */
+          })
+          .finally(() => {
+            if (reclassifySeqRef.current === seq) setAnalyzing(false);
+          });
+      }, RECLASSIFY_DEBOUNCE_MS);
+    },
+    [detectionBackend, mokuReady, rawImage, boardSize]
+  );
 
   // ── Debounced reclassify (called after corner drag) ───
   const scheduleReclassify = useCallback(
     (newCorners: BoardCorners) => {
-      if (!rawImage || !boardSize || !workerRef.current) return;
+      if (!rawImage || !boardSize) return;
 
       if (debounceRef.current) clearTimeout(debounceRef.current);
 
       const seq = ++reclassifySeqRef.current;
+
+      // In moku mode: update stones + grid immediately (cheap),
+      // defer the expensive warpPerspective to avoid UI freeze.
+      if (detectionBackend === 'moku' && result?.mokuRawDetections) {
+        if (warpDebounceRef.current) clearTimeout(warpDebounceRef.current);
+
+        const rawDets = result.mokuRawDetections!;
+        const stones = mapStonesToGrid(rawDets, newCorners, boardSize);
+
+        // Inset destination so the board has visible margins in the warped output
+        const WARP_MARGIN = 0.08;
+        const m = Math.round(800 * WARP_MARGIN);
+        const insetDst: [Point, Point, Point, Point] = [
+          [m, m],
+          [799 - m, m],
+          [799 - m, 799 - m],
+          [m, 799 - m],
+        ];
+        const grid: BoardCorners = insetDst;
+
+        // Immediately update stones + grid (no warp yet)
+        const partialResult: RecognitionResult = {
+          ...result,
+          boardSize,
+          stones,
+          corners: newCorners,
+          cornersDetected: true,
+          sgf: buildSGF(boardSize, stones),
+          estimatedGridCorners: grid,
+          mokuRawDetections: rawDets,
+        };
+        setResult(partialResult);
+        setGridCorners(grid);
+        gridCornersRef.current = grid;
+
+        // Defer the expensive warp
+        warpDebounceRef.current = setTimeout(() => {
+          if (reclassifySeqRef.current !== seq) return;
+          const warped = warpPerspective(rawImage, newCorners, 800, insetDst);
+          setResult(prev => (prev ? { ...prev, warpedImage: warped } : prev));
+          setWarpedURL(rawImageToDataURL(warped));
+        }, RECLASSIFY_DEBOUNCE_MS);
+        return;
+      }
+
+      // Classic mode: send to worker
+      if (!workerRef.current) return;
 
       debounceRef.current = setTimeout(() => {
         if (!workerRef.current) return;
@@ -260,7 +403,7 @@ export const BoardRecognitionDialog: React.FC<Props> = ({ file, onImport, onClos
           });
       }, RECLASSIFY_DEBOUNCE_MS);
     },
-    [rawImage, boardSize]
+    [rawImage, boardSize, detectionBackend, result]
   );
 
   // ── Reclassify with hints (called after calibration click) ──
@@ -566,7 +709,7 @@ export const BoardRecognitionDialog: React.FC<Props> = ({ file, onImport, onClos
   // ── Preview click for calibration ─────────────────────
   const onPreviewClick = useCallback(
     (col: number, row: number) => {
-      if (!calibrationMode || !boardSize) return;
+      if (!calibrationMode || !boardSize || !result) return;
 
       const color: StoneColor | 'empty' = calibrationMode;
       const newHint: CalibrationHint = { x: col, y: row, color };
@@ -575,9 +718,28 @@ export const BoardRecognitionDialog: React.FC<Props> = ({ file, onImport, onClos
       const updated = hints.filter(h => !(h.x === col && h.y === row));
       updated.push(newHint);
       setHints(updated);
-      reclassifyWithHints(updated);
+
+      if (detectionBackend === 'moku') {
+        // In moku mode, apply hints directly to the stones array
+        // without re-running any engine
+        const baseStones = result.stones.filter(
+          s => !updated.some(h => h.x === s.x && h.y === s.y)
+        );
+        const addedStones = updated
+          .filter(h => h.color !== 'empty')
+          .map(h => ({ x: h.x, y: h.y, color: h.color as StoneColor }));
+        const newStones = [...baseStones, ...addedStones];
+        const newResult: RecognitionResult = {
+          ...result,
+          stones: newStones,
+          sgf: buildSGF(result.boardSize as 9 | 13 | 19, newStones),
+        };
+        setResult(newResult);
+      } else {
+        reclassifyWithHints(updated);
+      }
     },
-    [calibrationMode, boardSize, hints, reclassifyWithHints]
+    [calibrationMode, boardSize, hints, reclassifyWithHints, detectionBackend, result]
   );
 
   // ── Import ────────────────────────────────────────────
@@ -618,6 +780,46 @@ export const BoardRecognitionDialog: React.FC<Props> = ({ file, onImport, onClos
               {s}×{s}
             </button>
           ))}
+          <span className="brd-size-sep" />
+          <span className="brd-size-label">{t('boardRecognition.backend')}</span>
+          <button
+            className={`brd-size-btn${detectionBackend === 'classic' ? ' active' : ''}`}
+            onClick={() => setDetectionBackend('classic')}
+          >
+            {t('boardRecognition.backendClassic')}
+          </button>
+          <button
+            className={`brd-size-btn${detectionBackend === 'moku' ? ' active' : ''}`}
+            onClick={() => setDetectionBackend('moku')}
+          >
+            {t('boardRecognition.backendMoku')}
+          </button>
+          {detectionBackend === 'moku' && (
+            <>
+              {mokuLoading && (
+                <span className="brd-moku-status brd-moku-loading">
+                  {t('boardRecognition.loadingModel')}
+                </span>
+              )}
+              {mokuReady && (
+                <>
+                  <span className="brd-size-label brd-threshold-label">
+                    {t('boardRecognition.threshold')}
+                  </span>
+                  <input
+                    type="range"
+                    className="brd-threshold-slider"
+                    min={0.01}
+                    max={0.99}
+                    step={0.01}
+                    value={mokuThreshold}
+                    onChange={e => handleMokuThresholdChange(Number(e.target.value))}
+                  />
+                  <span className="brd-threshold-value">{mokuThreshold.toFixed(2)}</span>
+                </>
+              )}
+            </>
+          )}
         </div>
 
         {loadError && <div className="brd-error">{loadError}</div>}

--- a/packages/ui/src/i18n/locales/de.json
+++ b/packages/ui/src/i18n/locales/de.json
@@ -619,6 +619,12 @@
     "markWhite": "Weißen Stein markieren",
     "markEmpty": "Leeren Schnittpunkt markieren",
     "resetCalibration": "Kalibrierung zurücksetzen",
-    "calibrateHint": "Klicken Sie auf Schnittpunkte in der Vorschau, um Fehler zu korrigieren"
+    "calibrateHint": "Klicken Sie auf Schnittpunkte in der Vorschau, um Fehler zu korrigieren",
+    "backend": "Erkennung:",
+    "backendClassic": "Klassisch",
+    "backendMoku": "Moku (KI)",
+    "threshold": "Schwellenwert:",
+    "loadingModel": "KI-Modell wird geladen…",
+    "mokuError": "KI-Erkennungsmodell konnte nicht geladen werden"
   }
 }

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -622,6 +622,12 @@
     "markWhite": "Mark white stone",
     "markEmpty": "Mark empty intersection",
     "resetCalibration": "Reset calibration",
-    "calibrateHint": "Click intersections on the preview to correct misdetections"
+    "calibrateHint": "Click intersections on the preview to correct misdetections",
+    "backend": "Detection:",
+    "backendClassic": "Classic",
+    "backendMoku": "Moku (AI)",
+    "threshold": "Threshold:",
+    "loadingModel": "Loading AI model…",
+    "mokuError": "Failed to load AI detection model"
   }
 }

--- a/packages/ui/src/i18n/locales/es.json
+++ b/packages/ui/src/i18n/locales/es.json
@@ -619,6 +619,12 @@
     "markWhite": "Marcar piedra blanca",
     "markEmpty": "Marcar intersección vacía",
     "resetCalibration": "Restablecer calibración",
-    "calibrateHint": "Haz clic en las intersecciones de la vista previa para corregir errores"
+    "calibrateHint": "Haz clic en las intersecciones de la vista previa para corregir errores",
+    "backend": "Detección:",
+    "backendClassic": "Clásico",
+    "backendMoku": "Moku (IA)",
+    "threshold": "Umbral:",
+    "loadingModel": "Cargando modelo de IA…",
+    "mokuError": "Error al cargar el modelo de detección IA"
   }
 }

--- a/packages/ui/src/i18n/locales/fr.json
+++ b/packages/ui/src/i18n/locales/fr.json
@@ -619,6 +619,12 @@
     "markWhite": "Marquer pierre blanche",
     "markEmpty": "Marquer intersection vide",
     "resetCalibration": "Réinitialiser la calibration",
-    "calibrateHint": "Cliquez sur les intersections de l'aperçu pour corriger les erreurs"
+    "calibrateHint": "Cliquez sur les intersections de l'aperçu pour corriger les erreurs",
+    "backend": "Détection :",
+    "backendClassic": "Classique",
+    "backendMoku": "Moku (IA)",
+    "threshold": "Seuil :",
+    "loadingModel": "Chargement du modèle IA…",
+    "mokuError": "Échec du chargement du modèle de détection IA"
   }
 }

--- a/packages/ui/src/i18n/locales/it.json
+++ b/packages/ui/src/i18n/locales/it.json
@@ -619,6 +619,12 @@
     "markWhite": "Segna pietra bianca",
     "markEmpty": "Segna intersezione vuota",
     "resetCalibration": "Reimposta calibrazione",
-    "calibrateHint": "Clicca sulle intersezioni nell'anteprima per correggere gli errori"
+    "calibrateHint": "Clicca sulle intersezioni nell'anteprima per correggere gli errori",
+    "backend": "Rilevamento:",
+    "backendClassic": "Classico",
+    "backendMoku": "Moku (IA)",
+    "threshold": "Soglia:",
+    "loadingModel": "Caricamento modello IA…",
+    "mokuError": "Impossibile caricare il modello di rilevamento IA"
   }
 }

--- a/packages/ui/src/i18n/locales/ja.json
+++ b/packages/ui/src/i18n/locales/ja.json
@@ -622,6 +622,12 @@
     "markWhite": "白石を指定",
     "markEmpty": "空き交点を指定",
     "resetCalibration": "補正をリセット",
-    "calibrateHint": "プレビュー上の交点をクリックして誤検出を修正"
+    "calibrateHint": "プレビュー上の交点をクリックして誤検出を修正",
+    "backend": "検出方法：",
+    "backendClassic": "クラシック",
+    "backendMoku": "Moku (AI)",
+    "threshold": "閾値：",
+    "loadingModel": "AIモデルを読み込み中…",
+    "mokuError": "AI検出モデルの読み込みに失敗しました"
   }
 }

--- a/packages/ui/src/i18n/locales/ko.json
+++ b/packages/ui/src/i18n/locales/ko.json
@@ -622,6 +622,12 @@
     "markWhite": "백돌 표시",
     "markEmpty": "빈 교차점 표시",
     "resetCalibration": "보정 초기화",
-    "calibrateHint": "미리보기에서 교차점을 클릭하여 오류를 수정하세요"
+    "calibrateHint": "미리보기에서 교차점을 클릭하여 오류를 수정하세요",
+    "backend": "감지 방식:",
+    "backendClassic": "클래식",
+    "backendMoku": "Moku (AI)",
+    "threshold": "임계값:",
+    "loadingModel": "AI 모델 로딩 중…",
+    "mokuError": "AI 감지 모델 로드 실패"
   }
 }

--- a/packages/ui/src/i18n/locales/zh.json
+++ b/packages/ui/src/i18n/locales/zh.json
@@ -622,6 +622,12 @@
     "markWhite": "标记白子",
     "markEmpty": "标记空位",
     "resetCalibration": "重置校准",
-    "calibrateHint": "点击预览中的交叉点以修正误检"
+    "calibrateHint": "点击预览中的交叉点以修正误检",
+    "backend": "检测方式：",
+    "backendClassic": "经典",
+    "backendMoku": "Moku (AI)",
+    "threshold": "阈值：",
+    "loadingModel": "正在加载 AI 模型…",
+    "mokuError": "AI 检测模型加载失败"
   }
 }

--- a/packages/ui/src/workers/BoardRecognitionWorker.ts
+++ b/packages/ui/src/workers/BoardRecognitionWorker.ts
@@ -7,6 +7,8 @@ import type {
   CalibrationHint,
   RecognitionOptions,
   RecognitionResult,
+  MokuDetectorConfig,
+  MokuDetectOptions,
 } from '@kaya/board-recognition';
 import type { WorkerRequest, WorkerResponse, SerializedResult } from './boardRecognition.worker';
 
@@ -30,6 +32,7 @@ function deserializeResult(s: SerializedResult): RecognitionResult {
       width: s.warpedSize,
       height: s.warpedSize,
     },
+    mokuRawDetections: s.mokuRawDetections,
   };
 }
 
@@ -51,6 +54,9 @@ export class BoardRecognitionWorker {
         p.reject(new Error(error));
       } else if (result) {
         p.resolve(deserializeResult(result));
+      } else {
+        // mokuInit / mokuDispose return no result
+        p.resolve(undefined as unknown as RecognitionResult);
       }
     };
   }
@@ -149,5 +155,63 @@ export class BoardRecognitionWorker {
       p.reject(new Error('Cancelled'));
     }
     this.pending.clear();
+  }
+
+  // ── Moku detector methods ──────────────────────────────
+
+  /** Initialize the moku ONNX detector (downloads and loads the model). */
+  mokuInit(config?: MokuDetectorConfig): Promise<void> {
+    const id = this.nextId++;
+    return new Promise<void>((resolve, reject) => {
+      this.pending.set(id, {
+        resolve: () => resolve(),
+        reject,
+      } as Pending);
+      this.worker.postMessage({
+        type: 'mokuInit' as const,
+        id,
+        config,
+      });
+    });
+  }
+
+  /** Run moku detection on an image. */
+  mokuDetect(
+    imgData: Uint8ClampedArray,
+    width: number,
+    height: number,
+    options: MokuDetectOptions
+  ): Promise<RecognitionResult> {
+    const id = this.nextId++;
+    const copy = imgData.buffer.slice(0) as ArrayBuffer;
+    return new Promise<RecognitionResult>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.worker.postMessage(
+        {
+          type: 'mokuDetect' as const,
+          id,
+          imgBuffer: copy,
+          width,
+          height,
+          options,
+        },
+        [copy]
+      );
+    });
+  }
+
+  /** Dispose the moku detector and free ONNX resources. */
+  mokuDispose(): Promise<void> {
+    const id = this.nextId++;
+    return new Promise<void>((resolve, reject) => {
+      this.pending.set(id, {
+        resolve: () => resolve(),
+        reject,
+      } as Pending);
+      this.worker.postMessage({
+        type: 'mokuDispose' as const,
+        id,
+      });
+    });
   }
 }

--- a/packages/ui/src/workers/boardRecognition.worker.ts
+++ b/packages/ui/src/workers/boardRecognition.worker.ts
@@ -6,6 +6,7 @@ import {
   recognizeBoard,
   reclassifyWithCorners,
   reclassifyWithHints,
+  MokuDetector,
 } from '@kaya/board-recognition';
 import type {
   RawImage,
@@ -13,6 +14,9 @@ import type {
   CalibrationHint,
   RecognitionOptions,
   RecognitionResult,
+  MokuDetectorConfig,
+  MokuDetectOptions,
+  MokuRawDetection,
 } from '@kaya/board-recognition';
 
 // ── Message protocol ────────────────────────────────────────────────────────
@@ -44,6 +48,23 @@ export type WorkerRequest =
       corners: BoardCorners;
       hints: CalibrationHint[];
       options: RecognitionOptions;
+    }
+  | {
+      type: 'mokuInit';
+      id: number;
+      config?: MokuDetectorConfig;
+    }
+  | {
+      type: 'mokuDetect';
+      id: number;
+      imgBuffer: ArrayBuffer;
+      width: number;
+      height: number;
+      options: MokuDetectOptions;
+    }
+  | {
+      type: 'mokuDispose';
+      id: number;
     };
 
 export interface WorkerResponse {
@@ -61,6 +82,7 @@ export interface SerializedResult {
   sgf: string;
   warpedBuffer: ArrayBuffer;
   warpedSize: number; // width === height
+  mokuRawDetections?: MokuRawDetection[];
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -83,10 +105,15 @@ function serializeResult(r: RecognitionResult): {
       sgf: r.sgf,
       warpedBuffer,
       warpedSize: r.warpedImage.width,
+      mokuRawDetections: r.mokuRawDetections,
     },
     transfer: [warpedBuffer],
   };
 }
+
+// ── Moku detector singleton ──────────────────────────────────────────────────
+
+let mokuDetector: MokuDetector | null = null;
 
 // ── Handler ──────────────────────────────────────────────────────────────────
 
@@ -110,6 +137,31 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
         const img = toRawImage(msg.imgBuffer, msg.width, msg.height);
         result = await reclassifyWithHints(img, msg.corners, msg.hints, msg.options);
         break;
+      }
+      case 'mokuInit': {
+        mokuDetector?.dispose();
+        mokuDetector = new MokuDetector(msg.config);
+        await mokuDetector.init();
+        (self as unknown as Worker).postMessage({
+          id: msg.id,
+          result: undefined,
+        } satisfies WorkerResponse);
+        return;
+      }
+      case 'mokuDetect': {
+        if (!mokuDetector) throw new Error('Moku detector not initialized');
+        const img = toRawImage(msg.imgBuffer, msg.width, msg.height);
+        result = await mokuDetector.detect(img, msg.options);
+        break;
+      }
+      case 'mokuDispose': {
+        mokuDetector?.dispose();
+        mokuDetector = null;
+        (self as unknown as Worker).postMessage({
+          id: msg.id,
+          result: undefined,
+        } satisfies WorkerResponse);
+        return;
       }
       default:
         return;


### PR DESCRIPTION
## Summary

Integrates the [kaya-go/moku-v1](https://huggingface.co/kaya-go/moku-v1) RT-DETR ONNX model as an alternative board detection backend for the board recognition feature.

## Changes

### New: Moku AI Detector (`packages/board-recognition/src/moku-detector.ts`)
- RT-DETR r18vd model (~20MB) detects board corners and stones directly via object detection
- 3 classes: black stone, white stone, board corner
- WASM-only ONNX Runtime with lazy dynamic import (no loading overhead unless moku is used)
- Argmax-per-query postprocessing (one query = one object)
- Preprocessing: resize to 640×640, rescale [0,255]→[0,1] only (no ImageNet normalization)
- Homography-based stone-to-grid mapping

### Board Recognition Dialog
- **Backend selector**: Classic / Moku (AI) toggle — **moku is the default**
- **Threshold slider**: Configurable confidence threshold (0.01–0.99, default 0.05)
- **Deferred warp**: Corner dragging updates stones + grid instantly, defers expensive warp to avoid UI freeze
- **Inset destination warp**: Board corners map to an inset region (8% margin) in the warped output, guaranteeing visible margins regardless of source image bounds
- **Manual calibration**: Stone editing works without re-running the engine in moku mode
- **Corner drag re-mapping**: Raw detections stored so stones can be re-mapped locally on corner change
- **Degenerate corners fallback**: When detected corners are all clustered together (<2% image area), falls back to inset image corners

### Worker Integration
- Added `mokuInit`, `mokuDetect`, `mokuDispose` message types and worker handlers
- `MokuRawDetection` type threaded through serialization for corner re-mapping
- Promise resolution fix for void worker responses

### Other
- `warpPerspective` now accepts optional `dstCorners` parameter for inset warping
- Exported `computeHomography`, `applyHomography` from `@kaya/board-recognition`
- Added `onnxruntime-web` dependency to `@kaya/board-recognition`
- i18n keys added for all 8 supported languages (en, zh, ko, ja, fr, de, es, it)

## Testing

- `bun run build:packages` ✅
- `bun run type-check` ✅
