### PR TITLE
fix(desktop): linux model download, glibc, F11 and audio diagnostics

### DIFF
--- a/.github/workflows/_build-linux-deb.yml
+++ b/.github/workflows/_build-linux-deb.yml
@@ -1,12 +1,14 @@
-name: Build Desktop (Linux AppImage)
+name: Build Desktop (Linux .deb/.rpm)
 
-# Builds the AppImage bundle. Runs in an Arch Linux container because
-# the new Tauri AppImage format (quick-sharun) requires Arch Linux.
-# See: https://github.com/tauri-apps/tauri/pull/12491
+# Builds Debian (.deb) and RPM (.rpm) packages on Ubuntu 22.04 so they
+# link against an older glibc (2.35), keeping them compatible with the
+# vast majority of Debian/Ubuntu/Mint/Fedora installs in the wild.
 #
-# The .deb and .rpm packages are built separately on Ubuntu 22.04 in
-# `_build-linux-deb.yml` to link against an older glibc (Arch's rolling
-# glibc 2.43+ otherwise breaks Debian/Ubuntu/Mint users). See #103.
+# The Arch-based AppImage build (`_build-linux.yml`) inherits Arch's
+# bleeding-edge glibc (currently 2.43) which breaks .deb users on
+# anything older than the latest rolling releases. AppImage stays on
+# Arch because the new quick-sharun format requires it; .deb/.rpm don't.
+# See: https://github.com/kaya-go/kaya/issues/103
 
 on:
   workflow_call:
@@ -19,7 +21,7 @@ on:
         default: ''
       artifact-name:
         type: string
-        default: 'desktop-linux'
+        default: 'desktop-linux-deb'
       artifact-retention-days:
         type: number
         default: 90
@@ -29,22 +31,24 @@ on:
 
 jobs:
   build:
-    name: Build Desktop - Linux (AppImage)
+    name: Build Desktop - Linux (.deb/.rpm)
     runs-on: ubuntu-latest
     container:
-      image: archlinux:base-devel
+      image: ubuntu:22.04
     steps:
       - name: Install system dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
-          pacman -Syu --noconfirm
-          pacman -S --noconfirm --needed \
-            git curl wget unzip \
-            clang cmake mold \
-            webkit2gtk-4.1 gtk3 libappindicator-gtk3 librsvg \
-            alsa-lib \
-            patchelf \
-            nodejs npm \
-            xorg-server-xvfb zsync
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential clang cmake mold pkg-config \
+            curl wget unzip git ca-certificates \
+            libwebkit2gtk-4.1-dev libgtk-3-dev \
+            libayatana-appindicator3-dev librsvg2-dev \
+            libasound2-dev \
+            patchelf rpm \
+            file sudo
 
       - uses: actions/checkout@v6
 
@@ -59,9 +63,9 @@ jobs:
         with:
           path: |
             ~/.bun/install/cache
-          key: Linux-arch-bun-cache-${{ hashFiles('**/bun.lock') }}
+          key: Linux-ubuntu22-bun-cache-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
-            Linux-arch-bun-cache-
+            Linux-ubuntu22-bun-cache-
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -94,10 +98,10 @@ jobs:
         continue-on-error: true
         with:
           path: ${{ steps.sccache_config.outputs.cache_path }}
-          key: Linux-arch-sccache-${{ steps.rust_keys.outputs.rustc_hash }}-${{ hashFiles('apps/desktop/src-tauri/Cargo.lock', 'packages/deadstones/src-rust/Cargo.lock') }}
+          key: Linux-ubuntu22-sccache-${{ steps.rust_keys.outputs.rustc_hash }}-${{ hashFiles('apps/desktop/src-tauri/Cargo.lock', 'packages/deadstones/src-rust/Cargo.lock') }}
           restore-keys: |
-            Linux-arch-sccache-${{ steps.rust_keys.outputs.rustc_hash }}-
-            Linux-arch-sccache-
+            Linux-ubuntu22-sccache-${{ steps.rust_keys.outputs.rustc_hash }}-
+            Linux-ubuntu22-sccache-
 
       - name: Enable sccache (strict)
         shell: bash
@@ -121,17 +125,15 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/bin
-          key: Linux-arch-cargo-${{ steps.rust_keys.outputs.rustc_hash }}-${{ hashFiles('apps/desktop/src-tauri/Cargo.lock', 'packages/deadstones/src-rust/Cargo.lock') }}
+          key: Linux-ubuntu22-cargo-${{ steps.rust_keys.outputs.rustc_hash }}-${{ hashFiles('apps/desktop/src-tauri/Cargo.lock', 'packages/deadstones/src-rust/Cargo.lock') }}
           restore-keys: |
-            Linux-arch-cargo-${{ steps.rust_keys.outputs.rustc_hash }}-
-            Linux-arch-cargo-
+            Linux-ubuntu22-cargo-${{ steps.rust_keys.outputs.rustc_hash }}-
+            Linux-ubuntu22-cargo-
 
-      # Install tauri-cli with new AppImage format (Arch Linux container)
-      # Uses the feat/truly-portable-appimage branch which uses quick-sharun
-      # See: https://github.com/tauri-apps/tauri/pull/12491
-      # TODO: Remove once this is merged into stable tauri-cli release
-      - name: Install tauri-cli with new AppImage format
-        run: cargo install tauri-cli --git https://github.com/tauri-apps/tauri --branch feat/truly-portable-appimage --force
+      # Stable tauri-cli is fine for .deb/.rpm — the truly-portable AppImage
+      # fork is only required for the AppImage bundle, which we don't produce here.
+      - name: Install tauri-cli
+        run: cargo install tauri-cli --version "^2.0" --locked
 
       - name: Install dependencies
         run: bun install
@@ -142,7 +144,7 @@ jobs:
           path: |
             ~/.cargo/bin/wasm-pack*
             ~/wasm-pack-*
-          key: Linux-arch-wasm-pack-0.13
+          key: Linux-ubuntu22-wasm-pack-0.13
 
       - name: Install wasm-pack
         shell: bash
@@ -157,39 +159,42 @@ jobs:
           KAYA_VERSION: ${{ inputs.set-version }}
         run: bun run set-version "$KAYA_VERSION"
 
-      # Bun's rsbuild crashes with SIGILL in the Arch Linux container.
-      # Workaround: pre-build packages with Bun (works fine), then use
-      # Node.js/npx for rsbuild, and skip Tauri's beforeBuildCommand.
       - name: Pre-build frontend
         run: |
           bun run generate-version-info
           bun run copy-assets
           bun run build:packages
-          cd apps/desktop && npx rsbuild build
+          cd apps/desktop && bun run --bun rsbuild build
 
-      - name: Build desktop app (AppImage only)
+      - name: Build desktop app (.deb + .rpm)
         working-directory: apps/desktop
-        run: cargo tauri build --bundles appimage --config '{"build":{"beforeBuildCommand":""}}'
+        run: cargo tauri build --bundles deb,rpm --config '{"build":{"beforeBuildCommand":""}}'
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_KEY_PASSWORD }}
-          TAURI_BUNDLER_NEW_APPIMAGE_FORMAT: 'true'
 
       - name: Collect artifact info
         shell: bash
         run: |
-          echo "Collecting Linux AppImage artifacts..."
-          find apps/desktop/src-tauri/target/release/bundle -type f -name "*.AppImage*" -exec ls -lh {} \;
+          echo "Collecting Linux .deb/.rpm artifacts..."
+          find apps/desktop/src-tauri/target/release/bundle -type f \( -name "*.deb" -o -name "*.rpm" \) -exec ls -lh {} \;
+          echo ""
+          echo "Verifying glibc compatibility of the binary..."
+          BIN=$(find apps/desktop/src-tauri/target/release -maxdepth 1 -type f -executable | head -1)
+          if [ -n "$BIN" ]; then
+            echo "Binary: $BIN"
+            objdump -T "$BIN" 2>/dev/null | grep -oE 'GLIBC_[0-9.]+' | sort -V -u | tail -5 || true
+          fi
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.artifact-name }}
           path: |
-            apps/desktop/src-tauri/target/release/bundle/appimage/
+            apps/desktop/src-tauri/target/release/bundle/deb/
+            apps/desktop/src-tauri/target/release/bundle/rpm/
           retention-days: ${{ inputs.artifact-retention-days }}
 
-      # Save caches only when they were not found
       - name: Save Cargo registry/git cache (if miss)
         if: ${{ !inputs.skip-cache && steps.cargo_cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v5

--- a/.github/workflows/_build-linux-deb.yml
+++ b/.github/workflows/_build-linux-deb.yml
@@ -144,13 +144,13 @@ jobs:
           path: |
             ~/.cargo/bin/wasm-pack*
             ~/wasm-pack-*
-          key: Linux-ubuntu22-wasm-pack-0.13
+          key: Linux-ubuntu22-wasm-pack-0.15.0
 
       - name: Install wasm-pack
         shell: bash
         run: |
           if ! command -v wasm-pack &> /dev/null; then
-            curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+            cargo install wasm-pack --version 0.15.0 --locked
           fi
 
       - name: Set version

--- a/.github/workflows/_build-linux.yml
+++ b/.github/workflows/_build-linux.yml
@@ -142,13 +142,13 @@ jobs:
           path: |
             ~/.cargo/bin/wasm-pack*
             ~/wasm-pack-*
-          key: Linux-arch-wasm-pack-0.13
+          key: Linux-arch-wasm-pack-0.15.0
 
       - name: Install wasm-pack
         shell: bash
         run: |
           if ! command -v wasm-pack &> /dev/null; then
-            curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+            cargo install wasm-pack --version 0.15.0 --locked
           fi
 
       - name: Set version

--- a/.github/workflows/_build-macos.yml
+++ b/.github/workflows/_build-macos.yml
@@ -133,13 +133,13 @@ jobs:
           path: |
             ~/.cargo/bin/wasm-pack*
             ~/wasm-pack-*
-          key: ${{ runner.os }}-wasm-pack-0.13
+          key: ${{ runner.os }}-wasm-pack-0.15.0
 
       - name: Install wasm-pack
         shell: bash
         run: |
           if ! command -v wasm-pack &> /dev/null; then
-            curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+            cargo install wasm-pack --version 0.15.0 --locked
           fi
 
       - name: Add Rust targets

--- a/.github/workflows/_build-windows.yml
+++ b/.github/workflows/_build-windows.yml
@@ -113,13 +113,13 @@ jobs:
           path: |
             ~/.cargo/bin/wasm-pack*
             ~/wasm-pack-*
-          key: ${{ runner.os }}-wasm-pack-0.13
+          key: ${{ runner.os }}-wasm-pack-0.15.0
 
       - name: Install wasm-pack
         shell: bash
         run: |
           if ! command -v wasm-pack &> /dev/null; then
-            curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+            cargo install wasm-pack --version 0.15.0 --locked
           fi
 
       - name: Set version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,12 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/wasm-pack
-          key: ${{ runner.os }}-wasm-pack
+          key: ${{ runner.os }}-wasm-pack-0.15.0
 
       - name: Install wasm-pack
         run: |
           if ! command -v wasm-pack &> /dev/null; then
-            curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+            cargo install wasm-pack --version 0.15.0 --locked
           fi
 
       - name: Check formatting
@@ -100,7 +100,7 @@ jobs:
       - name: Install wasm-pack
         run: |
           if ! command -v wasm-pack &> /dev/null; then
-            curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+            cargo install wasm-pack --version 0.15.0 --locked
           fi
 
       - name: Build Web App
@@ -147,7 +147,7 @@ jobs:
       - name: Install wasm-pack
         run: |
           if ! command -v wasm-pack &> /dev/null; then
-            curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+            cargo install wasm-pack --version 0.15.0 --locked
           fi
 
       - name: Install Tauri system dependencies
@@ -273,7 +273,7 @@ jobs:
       - name: Install wasm-pack
         run: |
           if ! command -v wasm-pack &> /dev/null; then
-            curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+            cargo install wasm-pack --version 0.15.0 --locked
           fi
 
       - name: Build packages

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,7 +37,7 @@ jobs:
     secrets: inherit
 
   build-linux:
-    name: Build Linux
+    name: Build Linux (AppImage)
     uses: ./.github/workflows/_build-linux.yml
     with:
       skip-cache: ${{ inputs.skip_cache || false }}
@@ -46,10 +46,20 @@ jobs:
       bun-version: '1.3.2'
     secrets: inherit
 
+  build-linux-deb:
+    name: Build Linux (.deb/.rpm)
+    uses: ./.github/workflows/_build-linux-deb.yml
+    with:
+      skip-cache: ${{ inputs.skip_cache || false }}
+      artifact-name: nightly-linux-deb
+      artifact-retention-days: 14
+      bun-version: '1.3.2'
+    secrets: inherit
+
   # Generate summary after all builds complete
   summary:
     name: Generate Summary
-    needs: [build-macos, build-windows, build-linux]
+    needs: [build-macos, build-windows, build-linux, build-linux-deb]
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
@@ -118,13 +128,23 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| File | Size |" >> $GITHUB_STEP_SUMMARY
           echo "|------|------|" >> $GITHUB_STEP_SUMMARY
+          # AppImage from Arch container
           if [ -d "artifacts/nightly-linux" ]; then
-            find artifacts/nightly-linux -type f \( -name "*.deb" -o -name "*.rpm" -o -name "*.AppImage" \) | while read file; do
+            find artifacts/nightly-linux -type f -name "*.AppImage" | while read file; do
               filename=$(basename "$file")
               size=$(ls -lh "$file" | awk '{print $5}')
               echo "| \`$filename\` | $size |" >> $GITHUB_STEP_SUMMARY
             done
-          else
+          fi
+          # .deb / .rpm from Ubuntu 22.04 container
+          if [ -d "artifacts/nightly-linux-deb" ]; then
+            find artifacts/nightly-linux-deb -type f \( -name "*.deb" -o -name "*.rpm" \) | while read file; do
+              filename=$(basename "$file")
+              size=$(ls -lh "$file" | awk '{print $5}')
+              echo "| \`$filename\` | $size |" >> $GITHUB_STEP_SUMMARY
+            done
+          fi
+          if [ ! -d "artifacts/nightly-linux" ] && [ ! -d "artifacts/nightly-linux-deb" ]; then
             echo "| *No artifacts found* | - |" >> $GITHUB_STEP_SUMMARY
           fi
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,10 @@ jobs:
       - name: Install wasm-pack
         run: command -v wasm-pack || curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-      - name: Set version to ${{ github.event.inputs.version }}
-        run: bun run set-version ${{ github.event.inputs.version }}
+      - name: Set version
+        env:
+          KAYA_VERSION: ${{ github.event.inputs.version }}
+        run: bun run set-version "$KAYA_VERSION"
 
       - name: Check formatting
         run: bun run format:check
@@ -70,7 +72,7 @@ jobs:
       - name: Run tests
         run: bun run test
 
-      - name: ✅ Verification passed
+      - name: Verification passed
         run: echo "All quality checks passed! Ready to build and release."
 
   deploy-web:
@@ -119,8 +121,10 @@ jobs:
       - name: Install wasm-pack
         run: command -v wasm-pack || curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-      - name: Set version to ${{ github.event.inputs.version }}
-        run: bun run set-version ${{ github.event.inputs.version }}
+      - name: Set version
+        env:
+          KAYA_VERSION: ${{ github.event.inputs.version }}
+        run: bun run set-version "$KAYA_VERSION"
 
       - name: Build packages
         run: bun run build:packages
@@ -155,6 +159,9 @@ jobs:
         run: echo "kayago.app" > gh-pages/CNAME
 
       - name: Deploy to GitHub Pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KAYA_VERSION: ${{ github.event.inputs.version }}
         run: |
           cd gh-pages
           git init
@@ -162,10 +169,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "Deploy v${{ github.event.inputs.version }}"
+          git commit -m "Deploy v${KAYA_VERSION}"
           git push --force "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-macos:
     name: Build macOS
@@ -188,7 +193,7 @@ jobs:
     secrets: inherit
 
   build-linux:
-    name: Build Linux
+    name: Build Linux (AppImage)
     needs: verify
     uses: ./.github/workflows/_build-linux.yml
     with:
@@ -197,10 +202,20 @@ jobs:
       bun-version: '1.3.2'
     secrets: inherit
 
+  build-linux-deb:
+    name: Build Linux (.deb/.rpm)
+    needs: verify
+    uses: ./.github/workflows/_build-linux-deb.yml
+    with:
+      set-version: ${{ github.event.inputs.version }}
+      artifact-name: desktop-linux-deb
+      bun-version: '1.3.2'
+    secrets: inherit
+
   # Commit version bump and create release ONLY after successful builds
   commit-and-release:
     name: Commit Version & Create Release
-    needs: [build-macos, build-windows, build-linux, deploy-web]
+    needs: [build-macos, build-windows, build-linux, build-linux-deb, deploy-web]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -218,19 +233,22 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Set version to ${{ github.event.inputs.version }}
-        run: bun run set-version ${{ github.event.inputs.version }}
+      - name: Set version
+        env:
+          KAYA_VERSION: ${{ github.event.inputs.version }}
+        run: bun run set-version "$KAYA_VERSION"
 
       - name: Generate changelog from commits
         id: changelog
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KAYA_VERSION: ${{ github.event.inputs.version }}
         run: |
           # Generate full changelog (skip_tags in cliff.toml handles old versions)
-          bun run git-cliff --tag "v${{ github.event.inputs.version }}" -o CHANGELOG.md
+          bun run git-cliff --tag "v${KAYA_VERSION}" -o CHANGELOG.md
 
           # Generate release notes for this version only
-          bun run git-cliff --tag "v${{ github.event.inputs.version }}" --unreleased --strip header -o CHANGELOG-NEW.md
+          bun run git-cliff --tag "v${KAYA_VERSION}" --unreleased --strip header -o CHANGELOG-NEW.md
 
           # Read the generated changelog for GitHub release
           CHANGELOG=$(cat CHANGELOG-NEW.md)
@@ -244,6 +262,8 @@ jobs:
           rm CHANGELOG-NEW.md
 
       - name: Commit and push version changes + changelog
+        env:
+          KAYA_VERSION: ${{ github.event.inputs.version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -252,22 +272,27 @@ jobs:
           bun run format
 
           git add .
-          git commit -m "chore: release v${{ github.event.inputs.version }}"
+          git commit -m "chore: release v${KAYA_VERSION}"
           git pull --rebase
           git push
 
       - name: Create and push tag
+        env:
+          KAYA_VERSION: ${{ github.event.inputs.version }}
         run: |
-          git tag -a "v${{ github.event.inputs.version }}" -m "Release v${{ github.event.inputs.version }}"
-          git push origin "v${{ github.event.inputs.version }}"
+          git tag -a "v${KAYA_VERSION}" -m "Release v${KAYA_VERSION}"
+          git push origin "v${KAYA_VERSION}"
 
       - name: Download all artifacts
         uses: actions/download-artifact@v8
 
       - name: Generate updater JSON
+        env:
+          KAYA_VERSION: ${{ github.event.inputs.version }}
+          KAYA_CHANGELOG: ${{ steps.changelog.outputs.changelog }}
         run: |
           # Generate latest.json for Tauri updater
-          bun run generate-updater-json "${{ github.event.inputs.version }}" "${{ steps.changelog.outputs.changelog }}"
+          bun run generate-updater-json "$KAYA_VERSION" "$KAYA_CHANGELOG"
 
       - name: Create Release
         uses: softprops/action-gh-release@v3
@@ -279,10 +304,10 @@ jobs:
             desktop-macos/**/*.dmg.sig
             desktop-macos/**/*.app.tar.gz
             desktop-macos/**/*.app.tar.gz.sig
-            desktop-linux/**/*.deb
-            desktop-linux/**/*.rpm
             desktop-linux/**/*.AppImage
             desktop-linux/**/*.AppImage.sig
+            desktop-linux-deb/**/*.deb
+            desktop-linux-deb/**/*.rpm
             desktop-windows/**/*.exe
             desktop-windows/**/*.exe.sig
             latest.json
@@ -324,8 +349,10 @@ jobs:
 
       - name: Calculate next version
         id: next_version
+        env:
+          KAYA_VERSION: ${{ github.event.inputs.version }}
         run: |
-          CURRENT_VERSION="${{ github.event.inputs.version }}"
+          CURRENT_VERSION="$KAYA_VERSION"
           # Split into parts
           IFS='.' read -r -a parts <<< "$CURRENT_VERSION"
           MAJOR="${parts[0]}"
@@ -340,13 +367,17 @@ jobs:
           echo "version=$NEXT_VERSION" >> $GITHUB_OUTPUT
 
       - name: Set version to next dev
-        run: bun run set-version ${{ steps.next_version.outputs.version }}
+        env:
+          KAYA_NEXT_VERSION: ${{ steps.next_version.outputs.version }}
+        run: bun run set-version "$KAYA_NEXT_VERSION"
 
       - name: Commit and push dev bump
+        env:
+          KAYA_NEXT_VERSION: ${{ steps.next_version.outputs.version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .
-          git commit -m "chore: bump version to ${{ steps.next_version.outputs.version }}"
+          git commit -m "chore: bump version to ${KAYA_NEXT_VERSION}"
           git pull --rebase
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,10 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/wasm-pack*
-          key: ${{ runner.os }}-wasm-pack-0.13
+          key: ${{ runner.os }}-wasm-pack-0.15.0
 
       - name: Install wasm-pack
-        run: command -v wasm-pack || curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        run: command -v wasm-pack || cargo install wasm-pack --version 0.15.0 --locked
 
       - name: Set version
         env:
@@ -116,10 +116,10 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/wasm-pack*
-          key: ${{ runner.os }}-wasm-pack-0.13
+          key: ${{ runner.os }}-wasm-pack-0.15.0
 
       - name: Install wasm-pack
-        run: command -v wasm-pack || curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        run: command -v wasm-pack || cargo install wasm-pack --version 0.15.0 --locked
 
       - name: Set version
         env:

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "kaya"
-version = "0.4.4-dev"
+version = "0.4.5-dev"
 dependencies = [
  "base64 0.22.1",
  "futures",

--- a/apps/desktop/src-tauri/src/audio.rs
+++ b/apps/desktop/src-tauri/src/audio.rs
@@ -22,8 +22,14 @@ impl AudioManager {
     /// Create a new AudioManager. Opens the default audio output device.
     /// Returns an error string if the device cannot be opened.
     pub fn new() -> Result<Self, String> {
-        let sink = DeviceSinkBuilder::open_default_sink()
-            .map_err(|e| format!("Failed to open audio device: {e}"))?;
+        let sink = DeviceSinkBuilder::open_default_sink().map_err(|e| {
+            let msg = format!("Failed to open audio device: {e}");
+            // Mirror to stderr — Linux AppImage users debugging silent audio
+            // can capture this by launching from a terminal.
+            eprintln!("[Audio] {msg}");
+            msg
+        })?;
+        eprintln!("[Audio] Opened default sink");
 
         Ok(Self {
             sink,
@@ -31,19 +37,25 @@ impl AudioManager {
         })
     }
 
-    /// Load a sound file from raw OGG bytes and associate it with a key.
-    pub fn load_sound(&mut self, key: String, data: Vec<u8>) {
+    /// Load a sound. Validates it can be decoded once up front so that broken
+    /// files or a missing/incompatible decoder surface at init time instead of
+    /// silently producing no audio on every play.
+    pub fn load_sound(&mut self, key: String, data: Vec<u8>) -> Result<(), String> {
+        Decoder::new(Cursor::new(data.clone())).map_err(|e| format!("decode failed: {e}"))?;
         self.sounds.insert(key, data);
+        Ok(())
     }
 
     /// Play a previously loaded sound by key. Non-blocking, fire-and-forget.
-    /// Returns silently if the sound key is not found or decoding fails.
+    /// Logs to stderr if the sound key is unknown or the decode fails.
     pub fn play(&self, key: &str) {
-        if let Some(data) = self.sounds.get(key) {
-            let cursor = Cursor::new(data.clone());
-            if let Ok(source) = Decoder::new(cursor) {
-                self.sink.mixer().add(source);
-            }
+        let Some(data) = self.sounds.get(key) else {
+            eprintln!("[Audio] play: unknown sound key '{key}'");
+            return;
+        };
+        match Decoder::new(Cursor::new(data.clone())) {
+            Ok(source) => self.sink.mixer().add(source),
+            Err(e) => eprintln!("[Audio] play: decode error for '{key}': {e}"),
         }
     }
 }
@@ -90,8 +102,13 @@ pub struct AudioState(pub std::sync::Mutex<Option<AudioManager>>);
 pub fn audio_init(app: tauri::AppHandle) -> Result<(), String> {
     let mut manager = AudioManager::new()?;
 
-    // Load all sound files from Tauri resources
+    // Load all sound files from Tauri resources. Collect per-file failure
+    // reasons so that if nothing loads we can surface a meaningful error to
+    // the UI (the existing sound-init-error toast) instead of silently going
+    // mute.
     let manifest = sound_manifest();
+    let total = manifest.len();
+    let mut failures: Vec<String> = Vec::new();
     for (key, resource_path) in &manifest {
         match app
             .path()
@@ -99,20 +116,34 @@ pub fn audio_init(app: tauri::AppHandle) -> Result<(), String> {
         {
             Ok(full_path) => match std::fs::read(&full_path) {
                 Ok(data) => {
-                    manager.load_sound(key.clone(), data);
+                    if let Err(e) = manager.load_sound(key.clone(), data) {
+                        eprintln!("[Audio] {resource_path}: {e}");
+                        failures.push(format!("{resource_path}: {e}"));
+                    }
                 }
                 Err(e) => {
                     eprintln!("[Audio] Warning: failed to read {resource_path}: {e}");
+                    failures.push(format!("{resource_path}: read error: {e}"));
                 }
             },
             Err(e) => {
                 eprintln!("[Audio] Warning: failed to resolve {resource_path}: {e}");
+                failures.push(format!("{resource_path}: resolve error: {e}"));
             }
         }
     }
 
     let loaded = manager.sounds.len();
-    println!("[Audio] Initialized with {loaded}/{} sounds", manifest.len());
+    println!("[Audio] Initialized with {loaded}/{total} sounds");
+
+    if loaded == 0 {
+        let detail = if failures.is_empty() {
+            "no sound files were found".to_string()
+        } else {
+            failures.join("; ")
+        };
+        return Err(format!("Audio init: no sounds loaded ({detail})"));
+    }
 
     // Store in Tauri state
     let state = app.state::<AudioState>();

--- a/apps/desktop/src-tauri/src/commands/upload.rs
+++ b/apps/desktop/src-tauri/src/commands/upload.rs
@@ -186,6 +186,29 @@ pub async fn onnx_cache_downloaded_file(
     })
 }
 
+/// Read a cached model's bytes from disk. Native fs read — bypasses the JS
+/// `@tauri-apps/plugin-fs` scope that rejects `$APPDATA` paths on Linux (#103).
+#[tauri::command]
+pub async fn onnx_read_model_bytes(
+    model_id: String,
+    app_handle: tauri::AppHandle,
+) -> Result<Vec<u8>, String> {
+    sanitize_model_id(&model_id)?;
+    let app_data = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {}", e))?;
+    let cached_path = app_data.join("models").join(format!("{}.onnx", model_id));
+
+    if !cached_path.exists() {
+        return Err(format!("Model not cached on disk: {}", model_id));
+    }
+
+    tokio::fs::read(&cached_path)
+        .await
+        .map_err(|e| format!("Failed to read cached model: {}", e))
+}
+
 /// Delete a cached model from the app data directory
 #[tauri::command]
 pub async fn onnx_delete_cached_model(model_id: String, app_handle: tauri::AppHandle) -> Result<bool, String> {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -31,6 +31,7 @@ pub fn run() {
             commands::onnx_save_model,
             commands::onnx_get_cached_model,
             commands::onnx_cache_downloaded_file,
+            commands::onnx_read_model_bytes,
             commands::onnx_delete_cached_model,
             commands::onnx_initialize,
             commands::onnx_initialize_base64,

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "kaya",
@@ -23,7 +22,7 @@
     },
     "apps/desktop": {
       "name": "@kaya/desktop",
-      "version": "0.4.4-dev",
+      "version": "0.4.5-dev",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
         "@dagrejs/graphlib": "^4.0.1",
@@ -61,7 +60,7 @@
     },
     "apps/web": {
       "name": "@kaya/web",
-      "version": "0.4.4-dev",
+      "version": "0.4.5-dev",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
         "@dagrejs/graphlib": "^4.0.1",
@@ -88,7 +87,7 @@
     },
     "packages/ai-engine": {
       "name": "@kaya/ai-engine",
-      "version": "0.4.4-dev",
+      "version": "0.4.5-dev",
       "dependencies": {
         "@kaya/gametree": "workspace:*",
         "@kaya/goboard": "workspace:*",
@@ -103,7 +102,7 @@
     },
     "packages/board-recognition": {
       "name": "@kaya/board-recognition",
-      "version": "0.4.4-dev",
+      "version": "0.4.5-dev",
       "dependencies": {
         "onnxruntime-web": "^1.24.3",
       },
@@ -114,7 +113,7 @@
     },
     "packages/boardmatcher": {
       "name": "@kaya/boardmatcher",
-      "version": "0.4.4-dev",
+      "version": "0.4.5-dev",
       "dependencies": {
         "@kaya/goboard": "workspace:*",
       },
@@ -124,17 +123,17 @@
     },
     "packages/deadstones": {
       "name": "@kaya/deadstones",
-      "version": "0.4.4-dev",
+      "version": "0.4.5-dev",
       "devDependencies": {
         "typescript": "^6.0.2",
       },
       "optionalDependencies": {
-        "wasm-pack": "^0.14.0",
+        "wasm-pack": "^0.15.0",
       },
     },
     "packages/game-library": {
       "name": "@kaya/game-library",
-      "version": "0.4.4-dev",
+      "version": "0.4.5-dev",
       "dependencies": {
         "@kaya/sgf": "workspace:*",
         "jszip": "^3.10.1",
@@ -146,7 +145,7 @@
     },
     "packages/gametree": {
       "name": "@kaya/gametree",
-      "version": "0.4.4-dev",
+      "version": "0.4.5-dev",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^6.0.2",
@@ -154,7 +153,7 @@
     },
     "packages/goboard": {
       "name": "@kaya/goboard",
-      "version": "0.4.4-dev",
+      "version": "0.4.5-dev",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^6.0.2",
@@ -162,7 +161,7 @@
     },
     "packages/i18n": {
       "name": "@kaya/i18n",
-      "version": "0.4.4-dev",
+      "version": "0.4.5-dev",
       "dependencies": {
         "i18next": "^26.0.3",
         "react-i18next": "^17.0.2",
@@ -178,7 +177,7 @@
     },
     "packages/platform": {
       "name": "@kaya/platform",
-      "version": "0.4.4-dev",
+      "version": "0.4.5-dev",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^6.0.2",
@@ -186,14 +185,14 @@
     },
     "packages/sgf": {
       "name": "@kaya/sgf",
-      "version": "0.4.4-dev",
+      "version": "0.4.5-dev",
       "devDependencies": {
         "typescript": "^6.0.2",
       },
     },
     "packages/shudan": {
       "name": "@kaya/shudan",
-      "version": "0.4.4-dev",
+      "version": "0.4.5-dev",
       "dependencies": {
         "@kaya/goboard": "workspace:*",
       },
@@ -207,7 +206,7 @@
     },
     "packages/themes": {
       "name": "@kaya/themes",
-      "version": "0.4.4-dev",
+      "version": "0.4.5-dev",
       "devDependencies": {
         "@types/react": "^19.2.14",
         "react": "^19.2.4",
@@ -219,7 +218,7 @@
     },
     "packages/ui": {
       "name": "@kaya/ui",
-      "version": "0.4.4-dev",
+      "version": "0.4.5-dev",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
         "@dagrejs/graphlib": "^4.0.1",
@@ -368,6 +367,8 @@
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
+
+    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
     "@kaya/ai-engine": ["@kaya/ai-engine@workspace:packages/ai-engine"],
 
@@ -635,15 +636,11 @@
 
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
 
-    "axios": ["axios@0.26.1", "", { "dependencies": { "follow-redirects": "^1.14.8" } }, "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA=="],
-
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
-
-    "binary-install": ["binary-install@1.1.2", "", { "dependencies": { "axios": "^0.26.1", "rimraf": "^3.0.2", "tar": "^6.1.11" } }, "sha512-ZS2cqFHPZOy4wLxvzqfQvDjCOifn+7uCPqNmYRIBM/03+yllON+4fNnsD0VJdW0p97y+E+dTRNPStWNqMBq+9g=="],
 
     "brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
@@ -663,7 +660,7 @@
 
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
 
-    "chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "classcat": ["classcat@5.0.5", "", {}, "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w=="],
 
@@ -678,8 +675,6 @@
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
-
-    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
 
@@ -767,13 +762,7 @@
 
     "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
 
-    "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
-
     "fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
-
-    "fs-minipass": ["fs-minipass@2.1.0", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg=="],
-
-    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
@@ -796,8 +785,6 @@
     "git-cliff-windows-arm64": ["git-cliff-windows-arm64@2.12.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-rFuI+D/3Yq3jqafazZw5E68HsXEvcwI/B/5IPDIZD+QqZh8vETf4IXs7wVxYWWtHQJDC+G9ZrR3vE5648mdG3A=="],
 
     "git-cliff-windows-x64": ["git-cliff-windows-x64@2.12.0", "", { "os": "win32", "cpu": "x64" }, "sha512-jskb3nyVGr4dekHSCDM/J6iho45t37wnmMGkPNq42kOoUp04JS96yMBrNRdXfXV9ViZsaZq3NaNu1e3QkhFlyA=="],
-
-    "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -830,8 +817,6 @@
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
-
-    "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
@@ -1013,11 +998,9 @@
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
-    "minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
-    "minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
-
-    "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
+    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
@@ -1026,8 +1009,6 @@
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "^4.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
-
-    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
@@ -1056,8 +1037,6 @@
     "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
-
-    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -1141,8 +1120,6 @@
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
-    "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
-
     "run-con": ["run-con@1.3.2", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~4.1.0", "minimist": "^1.2.8", "strip-json-comments": "~3.1.1" }, "bin": { "run-con": "cli.js" } }, "sha512-CcfE+mYiTcKEzg0IqS08+efdnH0oJ3zV0wSUFBNrMHMuxCtXvBCLzCJHatwuXDcu/RlhjTziTo/a1ruQik6/Yg=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
@@ -1197,7 +1174,7 @@
 
     "style-to-object": ["style-to-object@1.0.12", "", { "dependencies": { "inline-style-parser": "0.2.6" } }, "sha512-ddJqYnoT4t97QvN2C95bCgt+m7AAgXjVnkk/jxAfmp7EAB8nnqqZYEbMd3em7/vEomDb2LAQKAy1RFfv41mdNw=="],
 
-    "tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
+    "tar": ["tar@7.5.15", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ=="],
 
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
 
@@ -1247,7 +1224,7 @@
 
     "void-elements": ["void-elements@3.1.0", "", {}, "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="],
 
-    "wasm-pack": ["wasm-pack@0.14.0", "", { "dependencies": { "binary-install": "^1.1.2" }, "bin": { "wasm-pack": "run.js" } }, "sha512-7uKj+483b6ETTnuWHK3zKNB3Ca3M159tPZ5shyXxI4j7i9Lk82rL2ck/L6E9O5VMWk9JgowdtTBOSfWmGBRFtw=="],
+    "wasm-pack": ["wasm-pack@0.15.0", "", { "dependencies": { "tar": "^7.5.3" }, "bin": { "wasm-pack": "run.js" } }, "sha512-DdqtGWc3+iFx+7lL7QU5LBWs7qMnwQSWxF0htSfE15sNa3roVwHjAkTm2JXgueU2GGfSwNqbq2EzyC2b/biKDA=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
@@ -1257,9 +1234,7 @@
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
-    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
-
-    "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
@@ -1309,10 +1284,6 @@
 
     "dnd-core/redux": ["redux@4.2.1", "", { "dependencies": { "@babel/runtime": "^7.9.2" } }, "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w=="],
 
-    "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
-
-    "glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
-
     "globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "hast-util-to-jsx-runtime/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
@@ -1328,8 +1299,6 @@
     "mdast-util-to-markdown/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
-
-    "minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
@@ -1379,8 +1348,6 @@
 
     "dnd-core/redux/@babel/runtime": ["@babel/runtime@7.28.4", "", {}, "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="],
 
-    "glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
-
     "log-update/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "onnxruntime-web/protobufjs/@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
@@ -1394,8 +1361,6 @@
     "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
-    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "onnxruntime-web/protobufjs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
   }

--- a/packages/deadstones/package.json
+++ b/packages/deadstones/package.json
@@ -33,7 +33,7 @@
     "typescript": "^6.0.2"
   },
   "optionalDependencies": {
-    "wasm-pack": "^0.14.0"
+    "wasm-pack": "^0.15.0"
   },
   "dependencies": {}
 }

--- a/packages/ui/src/components/layout/useHeaderActions.ts
+++ b/packages/ui/src/components/layout/useHeaderActions.ts
@@ -458,6 +458,9 @@ export function useHeaderActions(options?: { onNavigateToBoard?: () => void }) {
         return;
       }
       if (matchesShortcut(e, 'view.toggleFullscreen')) {
+        // preventDefault matters for F11 on Linux/Wayland — some compositors
+        // would otherwise consume it for their own window fullscreen action.
+        e.preventDefault();
         toggleFullscreen();
         return;
       }

--- a/packages/ui/src/contexts/ai/engineLoader.ts
+++ b/packages/ui/src/contexts/ai/engineLoader.ts
@@ -3,9 +3,29 @@
  * concrete ArrayBuffer ready for the engine. Pure helper, no React.
  */
 
+import { isTauriApp } from '@kaya/platform';
 import { loadModelData } from '../../services/modelStorage';
 
 export type ModelDataSource = File | ArrayBuffer | string;
+
+function modelCacheIdFromStorageId(storageId: string): string {
+  return storageId.replace(/[^a-zA-Z0-9-_]/g, '_');
+}
+
+// On Tauri, downloaded models live on disk only; IndexedDB is the fallback
+// for user uploads not yet materialized via `onnx_finish_upload`. See #103.
+async function readFromTauriDiskCache(storageId: string): Promise<ArrayBuffer | null> {
+  try {
+    const { invoke } = await import('@tauri-apps/api/core');
+    const bytes = await invoke<number[] | Uint8Array>('onnx_read_model_bytes', {
+      modelId: modelCacheIdFromStorageId(storageId),
+    });
+    const u8 = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return u8.buffer.slice(u8.byteOffset, u8.byteOffset + u8.byteLength) as ArrayBuffer;
+  } catch {
+    return null;
+  }
+}
 
 export async function loadModelBuffer(data: ModelDataSource): Promise<ArrayBuffer> {
   if (data instanceof File) {
@@ -15,6 +35,10 @@ export async function loadModelBuffer(data: ModelDataSource): Promise<ArrayBuffe
     return data;
   }
   if (typeof data === 'string') {
+    if (isTauriApp()) {
+      const fromDisk = await readFromTauriDiskCache(data);
+      if (fromDisk) return fromDisk;
+    }
     const stored = await loadModelData(data);
     if (!stored) {
       throw new Error(`Model not found in storage: ${data}`);

--- a/packages/ui/src/hooks/game/useModelLibrary.ts
+++ b/packages/ui/src/hooks/game/useModelLibrary.ts
@@ -141,7 +141,7 @@ export function useModelLibrary() {
       );
 
       try {
-        let buffer: ArrayBuffer;
+        let downloadedSize: number;
 
         if (isTauriApp()) {
           // Use Rust-side download for reliable streaming + progress on all platforms
@@ -166,24 +166,20 @@ export function useModelLibrary() {
             // Rust downloads to a temp file and returns the path
             tempPath = await invoke<string>('download_file', { url: model.url });
 
-            // Cache the downloaded file directly in Rust's model cache dir.
-            // This avoids re-uploading via chunked IPC when the native engine initializes.
+            // Disk cache is the source of truth on Tauri — skip the IndexedDB
+            // mirror (would re-read $APPDATA via plugin-fs, rejected on Linux, #103).
             const modelCacheId = id.replace(/[^a-zA-Z0-9-_]/g, '_');
             const cacheResult = await invoke<{ path: string; size: number }>(
               'onnx_cache_downloaded_file',
               { tempPath, modelId: modelCacheId }
             );
-
-            // Read the cached copy into JS for IndexedDB storage
-            // (needed for web engine / WebGPU backend fallback)
-            const { readFile } = await import('@tauri-apps/plugin-fs');
-            const bytes = await readFile(cacheResult.path);
-            buffer = bytes.buffer as ArrayBuffer;
+            downloadedSize = cacheResult.size;
           } finally {
             unlisten();
           }
         } else {
-          // Web environment: Direct download from Hugging Face (CORS enabled)
+          // Web environment: Direct download from Hugging Face (CORS enabled).
+          // Browser users need the bytes in IndexedDB (no native disk cache).
           let response: Response;
           try {
             console.log(`[ModelDownload] Downloading: ${model.url}`);
@@ -219,7 +215,7 @@ export function useModelLibrary() {
 
           // Concatenate chunks into a single ArrayBuffer
           const totalLength = chunks.reduce((acc, chunk) => acc + chunk.length, 0);
-          buffer = new ArrayBuffer(totalLength);
+          const buffer = new ArrayBuffer(totalLength);
           const view = new Uint8Array(buffer);
           let offset = 0;
           for (const chunk of chunks) {
@@ -227,18 +223,18 @@ export function useModelLibrary() {
             offset += chunk.length;
           }
           chunks.length = 0;
+
+          await saveModelData(id, buffer);
+          downloadedSize = buffer.byteLength;
         }
 
-        // Save to storage
-        await saveModelData(id, buffer);
-
-        // Update metadata
+        // Update metadata (size comes from disk on Tauri, from buffer on web)
         const storedMetadata = await loadModelLibrary();
         const newMetadata: StoredModelMetadata = {
           id,
           name: model.name,
           description: model.description,
-          size: buffer.byteLength,
+          size: downloadedSize,
           date: Date.now(),
           predefinedId: model.predefinedId,
           url: model.url,
@@ -261,7 +257,7 @@ export function useModelLibrary() {
                   isDownloaded: true,
                   isDownloading: false,
                   downloadProgress: undefined,
-                  size: buffer.byteLength,
+                  size: downloadedSize,
                   date: Date.now(),
                 }
               : m

--- a/packages/ui/src/hooks/shortcutTypes.ts
+++ b/packages/ui/src/hooks/shortcutTypes.ts
@@ -152,7 +152,7 @@ export const DEFAULT_SHORTCUTS: Record<ShortcutId, Omit<ShortcutDefinition, 'id'
   },
   'view.toggleFullscreen': {
     category: 'view',
-    defaultBinding: createBinding('f'),
+    defaultBinding: createBinding('f11'),
   },
   'view.openSettings': {
     category: 'view',

--- a/packages/ui/src/hooks/shortcutUtils.ts
+++ b/packages/ui/src/hooks/shortcutUtils.ts
@@ -58,7 +58,11 @@ export function bindingToDisplayString(binding: KeyBinding): string {
       displayKey = ',';
       break;
     default:
-      displayKey = key.length === 1 ? key.toUpperCase() : key;
+      if (/^f\d{1,2}$/.test(key)) {
+        displayKey = key.toUpperCase();
+      } else {
+        displayKey = key.length === 1 ? key.toUpperCase() : key;
+      }
   }
 
   parts.push(displayKey);

--- a/specs/2026-05-23-linux-f11-and-audio-diagnostics.md
+++ b/specs/2026-05-23-linux-f11-and-audio-diagnostics.md
@@ -1,0 +1,101 @@
+---
+date: 2026-05-23
+status: shipped
+scope: desktop, ui
+---
+
+# Linux: F11 fullscreen and AppImage audio diagnostics
+
+Two long-standing Linux reports we cannot reproduce on macOS. Both shipped on the
+same release as the model-download / glibc fix because they share the same
+"can't test locally" constraint: the goal is to either ship a high-confidence fix
+or improve the diagnostics the next reporter can hand back to us.
+
+## #27 — F11 does not toggle fullscreen on Linux+Wayland
+
+The user is on Zorin OS 18 (Ubuntu 24.04 + GNOME, Wayland). The maximize button
+works; F11 does nothing.
+
+Root cause: F11 was never bound. `view.toggleFullscreen` defaulted to bare `'f'`
+in `shortcutTypes.ts`. F11 is the platform-conventional fullscreen key on
+Linux/Windows browsers and the user expected it.
+
+What shipped:
+
+- `view.toggleFullscreen` default binding moved from `'f'` → `'f11'`.
+- `bindingToDisplayString` formats `f<NN>` keys as uppercase (`F11`) instead of
+  the previous default that left them lowercased.
+- Added `e.preventDefault()` to the F11 branch in the document keydown handler.
+  On Wayland some compositors will swallow F11 for their own window action if
+  the page does not call preventDefault on the keydown.
+
+Trade-off: existing users who had memorized bare `'f'` lose the shortcut unless
+they rebind in Settings. We took it — `'f'` is a single bare letter that fires
+any time keyboard focus leaks out of a text input, which is a worse default than
+losing muscle memory for one key. Customizations stored in localStorage are
+preserved.
+
+Confidence the bug is gone on Wayland: medium-high. The handler is there; the
+binding is there; preventDefault is there. If the compositor still grabs F11
+before WebKitGTK sees it, we're stuck with a Tauri/WebKit upstream limitation,
+but the code-side is now correct.
+
+## #86 — AppImage audio is silent (web build works)
+
+Reporter says AppImage on Linux plays no sound; the web version on the same
+machine is fine. We cannot reproduce on macOS, and the existing init error path
+(toast surfaced via `setSoundInitErrorHandler`) reportedly never fires for them.
+That means either the device opens fine and something downstream silently fails,
+or the toast is being dismissed before they read it.
+
+The rodio backend had three silent-failure surfaces:
+
+1. `AudioManager::new()` logged the device-open error to JS but never to stderr,
+   so users running from a terminal saw nothing useful in the journal.
+2. `load_sound` stored the OGG bytes without decoding them. If lewton refused
+   the file (codec mismatch, AppImage resource corruption), the failure only
+   surfaced one byte at a time inside `play()` and was thrown away.
+3. `play()` silently dropped both unknown keys and decode errors.
+
+What shipped:
+
+- `AudioManager::new()` now mirrors device-open failures to stderr in addition
+  to the returned `Result`.
+- `load_sound` decodes the OGG once at load time. If the decode fails the
+  bytes are not inserted and the per-file error bubbles back into `audio_init`.
+- `audio_init` collects per-file failures. If zero sounds end up loaded it
+  returns an error that fires the existing JS sound-init-error toast with the
+  failure list, instead of silently storing an empty `AudioManager`.
+- `play()` logs unknown keys and decode errors to stderr.
+
+What this does and does not fix:
+
+- **Fixes**: any case where the audio is silent because all sounds failed to
+  load or decode. The user now gets a visible toast with the reason instead of
+  silence.
+- **Surfaces but does not fix**: cases where the device opens, the bytes
+  decode, but the sound never reaches the speakers (PipeWire routing, muted
+  default sink, ALSA grabbed by another process). The reporter can now run
+  the AppImage from a terminal — `./Kaya-*.AppImage 2>&1 | tee kaya.log` — and
+  hand us a log instead of "no sound."
+
+Why we did not change the rodio feature set: lewton-only is the current build.
+Adding `symphonia-vorbis` as a redundant decoder would help if lewton is the
+actual culprit, but it would bloat the binary on every platform to chase a
+hypothetical Linux-only decode bug. The new init validation will tell us
+whether decoding is actually the problem before we make that call.
+
+## Out of scope from #86
+
+The reporter also raised three analysis-engine observations:
+
+- Slower MCTS than Lizzie at 400 visits.
+- Different top moves vs. Lizzie at the same visit count.
+- The 400-visit cap is restrictive.
+
+These are not Linux-specific and overlap with the ongoing MCTS work in
+`specs/2026-05-04-ai-analysis-mcts-first.md`. Not addressed here because they
+need controlled benchmarking, not a blind change.
+
+Tracking issues: <https://github.com/kaya-go/kaya/issues/27>,
+<https://github.com/kaya-go/kaya/issues/86>

--- a/specs/2026-05-23-linux-model-download-and-glibc.md
+++ b/specs/2026-05-23-linux-model-download-and-glibc.md
@@ -1,0 +1,85 @@
+---
+date: 2026-05-23
+status: shipped
+scope: desktop, ci
+---
+
+# Linux: model download fix and glibc compatibility
+
+Two reports on the same release surface — issue #103 collected both:
+
+1. **Model download fails on Linux AppImage / .deb** with `forbidden path: $APPDATA/models/katago-latest-fp16.onnx`. The previous fix (commit `73da560`) repaired the streaming download, but a second bug remained downstream.
+2. **.deb fails to start with `GLIBC_2.43 not found`** on Debian/Ubuntu/Mint where glibc is older than 2.43.
+
+Both were Linux-only and could not be reproduced from the macOS dev environment, so they were going to keep slipping if we did not fix the structural cause for each.
+
+## The download path
+
+After commit `73da560` the flow was:
+
+1. Rust downloads the model into `/tmp/...` (covered by `fs:allow-temp-write` scope).
+2. Rust moves it to `$APPDATA/models/<id>.onnx` (native fs, no scope check).
+3. **JS calls `@tauri-apps/plugin-fs#readFile(cacheResult.path)`** to load it into an `ArrayBuffer`.
+4. JS writes that `ArrayBuffer` to IndexedDB.
+
+Step 3 is what fails on Linux. Tauri 2's fs plugin treats `$HOME` and `$APPDATA` as distinct scope tokens, even when the resolved path of `$APPDATA` sits literally inside `$HOME`. The capabilities granted `fs:allow-home-read-recursive` but no `fs:allow-app*-read*`, so the JS `readFile` call was rejected with `forbidden path`.
+
+On macOS the same scope rules apply, but `app_data_dir()` returns `~/Library/Application Support/com.kaya.desktop/`, which has no dot-prefixed segment and matched the home scope. On Linux it returns `~/.local/share/com.kaya.desktop/` and the scope refuses it.
+
+### Why not just widen the scope
+
+A one-line fix — add `fs:allow-appdata-read-recursive` to `capabilities/default.json` — would close the bug. But once the file is already on disk via Rust, reading it back into JS just to re-write it into IndexedDB does three things we do not need on Tauri:
+
+- Allocates ~280 MB in the JS heap for a buffer the native engine never consumes (the native engine path uses `onnx_get_cached_model` + `onnx_initialize_from_path`).
+- Duplicates the model bytes on disk (IndexedDB SQLite + `$APPDATA/models/`).
+- Re-introduces fs-scope as a failure mode for any future packaging target.
+
+### What shipped
+
+A new Rust command `onnx_read_model_bytes(model_id) -> Vec<u8>` reads the cached model directly via native `tokio::fs::read`. The JS `loadModelBuffer` helper in `engineLoader.ts` now tries that command first on Tauri and falls back to IndexedDB:
+
+- Downloaded models: live on disk only on Tauri. `loadModelBuffer` reads from disk.
+- User-uploaded models: still in IndexedDB until first engine init (which calls `onnx_finish_upload` to materialize them on disk). `loadModelBuffer` falls back to IndexedDB until then.
+- Web users: branch is unchanged. Direct fetch → IndexedDB.
+
+The `useModelLibrary.downloadModel` hook stops calling `@tauri-apps/plugin-fs#readFile` and `saveModelData` on the Tauri branch — it uses `cacheResult.size` for the stored metadata.
+
+Side-effect surface considered:
+
+- **Native engine path** (Tauri / GPU / CPU): unchanged. Reads from disk via `onnx_get_cached_model`.
+- **WebGPU / WASM engine on Tauri**: now sources bytes from the new Rust command instead of IndexedDB. Identical bytes, no behaviour change.
+- **Cache-miss path** in `tauri-engine.ts`: still uses chunked IPC upload from `modelBuffer`, which `loadModelBuffer` now sources from the new command. No change.
+- **Old-version users with IndexedDB-only state**: protected by the IndexedDB fallback in `loadModelBuffer`.
+- **Disk usage**: now single-stored on Tauri (in `$APPDATA/models/`) instead of duplicated. Net win.
+
+## The glibc fix
+
+The Linux build runs in `archlinux:base-devel` because the new Tauri AppImage format (`quick-sharun`, currently on the `feat/truly-portable-appimage` branch of tauri-cli) requires Arch Linux. Arch is rolling, so its glibc is on whatever the upstream just shipped — currently 2.43. The .deb and .rpm packages inherit that requirement and break on any distro with an older glibc, which is most of the install base (Ubuntu 22.04 = 2.35, Ubuntu 24.04 = 2.39, LMDE 7 = 2.41).
+
+Options considered:
+
+1. **Drop .deb and .rpm**, ship AppImage only. Simplest. AppImage works on every Linux distro because it ships its own bundled dependencies. But it would be a regression for the rolling-distro users who currently have a working .deb, and removes a packaging promise from the release table.
+2. **Split the build** — keep AppImage on Arch (it has to), build .deb/.rpm on Ubuntu 22.04. ~5 min added to CI time, two parallel jobs. No user-facing regression.
+
+We went with (2) because the user-facing "no regression" constraint was explicit.
+
+### What shipped
+
+- `_build-linux-deb.yml`: new reusable workflow. Runs on `ubuntu:22.04` container, installs apt deps (`libwebkit2gtk-4.1-dev`, `libgtk-3-dev`, `librsvg2-dev`, `libasound2-dev`, `rpm`, etc.), uses the stable tauri-cli (no fork needed because we're not producing AppImages here), runs `cargo tauri build --bundles deb,rpm`. Uploads under `desktop-linux-deb` artifact. Emits glibc version probe via `objdump -T` so a regression would be visible in the build logs.
+- `_build-linux.yml`: still on Arch, now runs `cargo tauri build --bundles appimage` and uploads only the `appimage/` subdir.
+- `release.yml`: gained a `build-linux-deb` job, `commit-and-release` depends on it, and the `softprops/action-gh-release` file list pulls `.deb`/`.rpm` from `desktop-linux-deb/` and `.AppImage`/`.AppImage.sig` from `desktop-linux/`.
+- `nightly.yml`: same split, so the .deb path gets exercised weekly instead of only at release time.
+
+Why Ubuntu 22.04 specifically: glibc 2.35 is the oldest LTS we want to chase (20.04 LTS reached EOL April 2025), and it's forward-compatible with Ubuntu 24.04, Mint 22, LMDE 7, Debian 12, Fedora 39+ — every distro the issue reporters were on.
+
+### Cleanup at the same time
+
+The workflow files now use `env:` blocks for `${{ github.event.inputs.version }}` and `${{ inputs.set-version }}` references in `run:` steps instead of inlining them. Not a functional change — closes the workflow-injection vector that the project's superpowers security hook flags. The existing patterns elsewhere are unchanged; this just stops the new files from introducing more.
+
+## Things explicitly not done
+
+- **Read the cached model bytes lazily**. `loadModelBuffer` still loads the full buffer eagerly in `AIEngineContext`, before the backend chain is picked. On the native path the buffer is never consumed; that ~280 MB of JS heap is wasted on Tauri. Worth a follow-up but out of scope here — the native engine still works, the waste is invisible at runtime.
+- **Cache user-uploaded models on disk at upload time**. Currently they only land on disk after the first engine init triggers `onnx_finish_upload`. Same trade-off as above — works correctly, just not optimal.
+- **Drop `@tauri-apps/plugin-fs` from `packages/ui`**. Still used by `useDropZoneEffects.ts` for SGF drops; removing the `readFile` call in `useModelLibrary.ts` is enough to fix the bug without touching the dependency.
+
+Tracking issue: <https://github.com/kaya-go/kaya/issues/103>


### PR DESCRIPTION
## Summary

Closes #103, #27, partial relief for #86 — three Linux reports bundled in one release since they share the "can't reproduce on macOS" constraint.

### 1. Model download fails on Linux with `forbidden path` (#103)

The previous fix (73da560) repaired the streaming download, but a second bug remained: after writing to `$APPDATA/models/<id>.onnx`, the JS side called `@tauri-apps/plugin-fs#readFile` to load it back and mirror to IndexedDB. Tauri 2's fs plugin treats `\$HOME` and `\$APPDATA` as distinct scope tokens, so `\$APPDATA` paths get rejected on Linux even when literally inside \$HOME. macOS hid this because `app_data_dir()` resolves to `~/Library/Application Support/…` (matched by the home scope).

This PR replaces the readFile + IndexedDB roundtrip on Tauri with a new Rust command `onnx_read_model_bytes` (native fs read, no JS scope) and drops the IndexedDB write on the Tauri branch. Disk becomes the source of truth; IndexedDB stays as the fallback path for user uploads not yet materialized via `onnx_finish_upload`, and remains unchanged on web. The `loadModelBuffer` helper transparently tries disk first on Tauri.

Side-effect surface in [specs/2026-05-23-linux-model-download-and-glibc.md](specs/2026-05-23-linux-model-download-and-glibc.md).

### 2. .deb fails to start: `GLIBC_2.43 not found` (#103)

The Linux build runs in an Arch Linux container (required for the new AppImage quick-sharun format). Arch ships bleeding-edge glibc 2.43, so the .deb/.rpm inherited it and broke users on Ubuntu LTS, Mint, Debian stable, etc.

Split the Linux build:
- `_build-linux.yml` — Arch container, builds **AppImage only** (`--bundles appimage`).
- `_build-linux-deb.yml` (new) — Ubuntu 22.04 container (glibc 2.35, forward-compatible), builds **.deb/.rpm only** (`--bundles deb,rpm`). Includes a `objdump -T` glibc probe in the build log so regressions are visible.
- `release.yml` + `nightly.yml` — call both workflows, pull artifacts from `desktop-linux/` (AppImage) and `desktop-linux-deb/` (.deb/.rpm).

### 3. F11 does not toggle fullscreen on Linux+Wayland (#27)

`view.toggleFullscreen` defaulted to bare `'f'`, which (a) is not the platform convention and (b) fires whenever focus leaks out of a text input. F11 was never bound at all, so the Wayland reporter pressing F11 saw nothing happen.

- Default binding for `view.toggleFullscreen` moved from `'f'` → `'f11'`. Customizations in localStorage are preserved.
- `e.preventDefault()` added to the F11 keydown branch so Wayland compositors don't grab it before WebKitGTK sees it.
- `bindingToDisplayString` formats `f<NN>` as uppercase `F<NN>` in the shortcuts UI.

### 4. AppImage audio diagnostics (#86 — partial)

We can't reproduce the AppImage-silent-audio bug on macOS. This PR doesn't fix the underlying audio routing (which is likely a system-side ALSA/PipeWire issue), but closes the three silent-failure surfaces in the rodio backend so the next reporter can hand us a real error instead of "no sound":

- `AudioManager::new()` mirrors device-open failures to stderr in addition to the JS toast.
- `load_sound` now decodes each OGG once at init. If lewton refuses the file the bytes are not inserted and the failure bubbles up.
- `audio_init` collects per-file failures and returns a structured error if zero sounds load — fires the existing `setSoundInitErrorHandler` toast with the failure list instead of silently storing an empty manager.
- `play()` logs unknown keys and decode errors to stderr.

Reporter can now `./Kaya-*.AppImage 2>&1 | tee kaya.log` and hand us the actual error. See [specs/2026-05-23-linux-f11-and-audio-diagnostics.md](specs/2026-05-23-linux-f11-and-audio-diagnostics.md) for the analysis-engine observations from #86 that we explicitly didn't touch (slower-than-Lizzie, different top moves, 400-visit cap — these need controlled benchmarking, not blind changes).

### 5. Workflow-injection cleanup

Moved `\${{ github.event.inputs.version }}` and `\${{ inputs.set-version }}` references that lived inside `run:` blocks to `env:` blocks. Existing patterns elsewhere are untouched.

## Test plan

- [x] `bun run type-check` — all 15 packages pass
- [x] `bun run test` — 153 tests pass
- [x] `bun run format:check` — clean
- [x] `cargo check` on `apps/desktop/src-tauri` — passes
- [ ] CI Linux AppImage build (Arch)
- [ ] CI Linux .deb/.rpm build (Ubuntu 22.04) — first run will validate glibc 2.35 in `objdump -T` output
- [ ] Smoke test on Linux: download model via UI on .deb / AppImage / glibc 2.41 host
- [ ] macOS smoke test: download + native + WebGPU backends
- [ ] F11 toggles fullscreen on Linux+Wayland (issue #27 reporter)
- [ ] AppImage launched from terminal surfaces an actionable audio error (issue #86 reporter)

Specs: [model download + glibc](specs/2026-05-23-linux-model-download-and-glibc.md), [F11 + audio diagnostics](specs/2026-05-23-linux-f11-and-audio-diagnostics.md)