### PR TITLE
fix(ui): avoid desktop white screen by skipping eager model copy

### DIFF
--- a/packages/ui/src/contexts/AIEngineContext.tsx
+++ b/packages/ui/src/contexts/AIEngineContext.tsx
@@ -25,10 +25,16 @@ import { useTranslation } from 'react-i18next';
 import { isTauriApp, writeClipboardText } from '@kaya/platform';
 import { useGameTree } from './GameTreeContext';
 import { useToast } from '../components/ui/Toast';
-import { parseModelId, getModelId } from '../hooks/game/useAIAnalysis';
+import { parseModelId } from '../hooks/game/useAIAnalysis';
 import type { ModelQuantization } from '../hooks/game/ai-analysis-types';
 import type { AISettings } from '../types/game';
-import { loadModelBuffer, modelIdFromName, resolveWasmPath } from './ai/engineLoader';
+import {
+  getTauriCachedModelPath,
+  loadModelBuffer,
+  modelCacheIdFromStorageId,
+  modelIdFromName,
+  resolveWasmPath,
+} from './ai/engineLoader';
 import { tryEngineChain, type ChainStepEvent } from './ai/engineChain';
 import { idleStatus, isReady, type EngineStatus } from './ai/engineStatus';
 import {
@@ -204,6 +210,11 @@ export const AIEngineProvider: React.FC<{ children: React.ReactNode }> = ({ chil
           const chain = resolveBackendChain(aiSettings, autoPick);
           const modelName = customAIModel?.name || '';
           const quant = quantFromModelName(modelName);
+          const modelData = customAIModel.data;
+          const modelId =
+            typeof modelData === 'string'
+              ? modelCacheIdFromStorageId(modelData)
+              : modelIdFromName(modelName);
 
           setStatus({
             phase: 'loading-model',
@@ -211,10 +222,14 @@ export const AIEngineProvider: React.FC<{ children: React.ReactNode }> = ({ chil
             quantization: quant,
           });
 
-          const buffer = await loadModelBuffer(customAIModel.data);
+          const modelPath = isTauri ? await getTauriCachedModelPath(modelData) : null;
+          const needsModelBuffer = chain.some(
+            backend => backend === 'webgpu' || backend === 'wasm'
+          );
+          const buffer =
+            !modelPath || needsModelBuffer ? await loadModelBuffer(modelData) : undefined;
 
           const wasmPath = resolveWasmPath(isTauri);
-          const modelId = modelIdFromName(modelName);
           const workerFactory = () =>
             new Worker(new URL('../workers/ai.worker.js', import.meta.url), { type: 'module' });
 
@@ -238,6 +253,7 @@ export const AIEngineProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 
           const result = await tryEngineChain(chain, {
             modelBuffer: buffer,
+            modelPath: modelPath ?? undefined,
             modelName,
             modelId,
             boardSize,

--- a/packages/ui/src/contexts/ai/engineChain.ts
+++ b/packages/ui/src/contexts/ai/engineChain.ts
@@ -27,7 +27,9 @@ export interface ChainStepEvent {
 }
 
 export interface EngineChainConfig {
-  modelBuffer: ArrayBuffer;
+  modelBuffer?: ArrayBuffer;
+  /** Native desktop backends can initialize directly from disk. */
+  modelPath?: string;
   /** User-visible model name; used to detect static-batch / .webgpu. variants. */
   modelName: string;
   /** Stable ID for the model (Tauri caching key). */
@@ -107,6 +109,9 @@ async function initOneBackend(backend: BackendId, cfg: EngineChainConfig): Promi
       engineType = 'pytorch';
       break;
     case 'webgpu': {
+      if (!buffer) {
+        throw new Error('Model bytes are required for the WebGPU backend');
+      }
       executionProviders = ['webgpu'];
       const needsConversion = !cfg.isTauri && !isWebGPUOptimized(cfg.modelName);
       if (cfg.modelName.includes('.webgpu.') || needsConversion) {
@@ -126,6 +131,9 @@ async function initOneBackend(backend: BackendId, cfg: EngineChainConfig): Promi
       break;
     }
     case 'wasm':
+      if (!buffer) {
+        throw new Error('Model bytes are required for the WASM backend');
+      }
       executionProviders = ['wasm'];
       break;
   }
@@ -139,6 +147,7 @@ async function initOneBackend(backend: BackendId, cfg: EngineChainConfig): Promi
   return createEngine(
     {
       modelBuffer: buffer,
+      modelPath: cfg.modelPath,
       modelId: cfg.modelId,
       executionProvider: backend === 'native-cpu' ? 'cpu' : 'auto',
       engineType,
@@ -191,6 +200,9 @@ async function safeDispose(engine: Engine): Promise<void> {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function _initWebNN(cfg: EngineChainConfig): Promise<Engine> {
   let buffer = cfg.modelBuffer;
+  if (!buffer) {
+    throw new Error('Model bytes are required for the WebNN backend');
+  }
   let staticBatchSize = cfg.webgpuBatchSize || WEBGPU_BATCH_SIZE;
   if (!cfg.isTauri && !isWebNNOptimized(cfg.modelName)) {
     try {

--- a/packages/ui/src/contexts/ai/engineLoader.ts
+++ b/packages/ui/src/contexts/ai/engineLoader.ts
@@ -8,8 +8,20 @@ import { loadModelData } from '../../services/modelStorage';
 
 export type ModelDataSource = File | ArrayBuffer | string;
 
-function modelCacheIdFromStorageId(storageId: string): string {
+export function modelCacheIdFromStorageId(storageId: string): string {
   return storageId.replace(/[^a-zA-Z0-9-_]/g, '_');
+}
+
+export async function getTauriCachedModelPath(data: ModelDataSource): Promise<string | null> {
+  if (!isTauriApp() || typeof data !== 'string') return null;
+  try {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return await invoke<string | null>('onnx_get_cached_model', {
+      modelId: modelCacheIdFromStorageId(data),
+    });
+  } catch {
+    return null;
+  }
 }
 
 // On Tauri, downloaded models live on disk only; IndexedDB is the fallback

--- a/specs/2026-05-23-linux-model-download-and-glibc.md
+++ b/specs/2026-05-23-linux-model-download-and-glibc.md
@@ -78,7 +78,7 @@ The workflow files now use `env:` blocks for `${{ github.event.inputs.version }}
 
 ## Things explicitly not done
 
-- **Read the cached model bytes lazily**. `loadModelBuffer` still loads the full buffer eagerly in `AIEngineContext`, before the backend chain is picked. On the native path the buffer is never consumed; that ~280 MB of JS heap is wasted on Tauri. Worth a follow-up but out of scope here — the native engine still works, the waste is invisible at runtime.
+- **Read the cached model bytes lazily**. `loadModelBuffer` still loads the full buffer eagerly in `AIEngineContext`, before the backend chain is picked. On the native path the buffer is never consumed; that ~280 MB of JS heap is wasted on Tauri. Worth a follow-up but out of scope here — the native engine still works, the waste is invisible at runtime. _(Follow-up done [2026-06-09](2026-06-09-lazy-model-buffer-native-path.md) — the waste was **not** invisible: it white-screened the desktop app for large models.)_
 - **Cache user-uploaded models on disk at upload time**. Currently they only land on disk after the first engine init triggers `onnx_finish_upload`. Same trade-off as above — works correctly, just not optimal.
 - **Drop `@tauri-apps/plugin-fs` from `packages/ui`**. Still used by `useDropZoneEffects.ts` for SGF drops; removing the `readFile` call in `useModelLibrary.ts` is enough to fix the bug without touching the dependency.
 

--- a/specs/2026-06-09-lazy-model-buffer-native-path.md
+++ b/specs/2026-06-09-lazy-model-buffer-native-path.md
@@ -1,0 +1,73 @@
+---
+date: 2026-06-09
+status: shipped
+scope: ai, desktop
+---
+
+# Skip the eager JS-heap model copy on the native desktop path
+
+White screen on desktop when starting analysis with a cached model. PR #116.
+
+## Context
+
+[2026-05-23](2026-05-23-linux-model-download-and-glibc.md) moved downloaded
+models to disk-only on Tauri and deferred one follow-up: `loadModelBuffer`
+in `AIEngineContext` still read the **full** ONNX file into an `ArrayBuffer`
+eagerly, before the backend chain was even picked. That spec judged the waste
+"invisible at runtime — the native engine still works."
+
+It wasn't invisible. The native backends (ORT / PyTorch) initialize from disk
+via `onnx_get_cached_model` + `onnx_initialize_from_path` and never touch the
+buffer, so on desktop that eager read allocated 140–280 MB in the WebView JS
+heap for nothing. For the fp32 (~280 MB) and fp16 (~140 MB) models the
+allocation plus the chunked-IPC churn was enough to white-screen the app.
+
+A second, quieter bug surfaced while tracing it: the engine's `modelId` was
+derived from the model **name** (`modelIdFromName` → `kata1-b28c512nbt-s12043M__Balanced_`),
+but downloaded models live on disk under the sanitized **storage id**
+(`katago-latest-fp16.onnx`, see the 2026-05-23 note). So `TauriEngine`'s own
+`onnx_get_cached_model` lookup missed for every predefined model and fell
+through to the chunked-upload path — re-uploading the bytes it had just read
+and writing a duplicate `<name-id>.onnx` to disk on first init. The
+"reads from disk" path the 2026-05-23 spec described was not actually
+engaging for the predefined lineup.
+
+## Decision
+
+In `AIEngineContext` engine init:
+
+- On Tauri, resolve the on-disk path up front via a new
+  `getTauriCachedModelPath` helper in `engineLoader.ts` (wraps
+  `onnx_get_cached_model`, returns `null` for non-string data or any error).
+- Load the buffer **only** when there is no disk path (cache miss) or a
+  backend in the chain needs bytes — `needsModelBuffer = chain.some(b => b === 'webgpu' || b === 'wasm')`.
+  Desktop auto chains are native-only (WebGPU is unavailable in the Tauri
+  WebView, [2026-05-03](2026-05-03-webgpu-unavailable-in-tauri-webview.md)),
+  so the buffer is skipped entirely.
+- Thread `modelPath` through `EngineChainConfig` → `createEngine` → the native
+  and PyTorch engines, which already accepted it end-to-end; this just wired
+  it through. `modelBuffer` becomes optional, with explicit guards on the
+  web backends (`webgpu` / `wasm` / `_initWebNN`).
+- Compute `modelId` from the storage id when `data` is a string, so it matches
+  the on-disk cache key. This is what makes the native cache lookup hit (no
+  more redundant upload / duplicate file) and what `getTauriCachedModelPath`
+  keys on.
+
+## Learnings
+
+- "The waste is invisible at runtime" was wrong — eager buffer allocation in
+  the WebView is a real failure mode for large models. Allocate lazily, after
+  the backend chain is known.
+- `modelId` is consumed **only** as the native disk-cache key (`tauri-engine`,
+  `pytorch-tauri-engine`); the web/worker engines and the analysis cache don't
+  use it. Aligning it with the storage id is therefore safe for web (where the
+  buffer is still always loaded — `isTauri` is false).
+- Minor residual: users who ran the buggy version may have an orphaned
+  `<name-id>.onnx` duplicate on disk from the old upload fallback. Harmless and
+  self-healing (the active path no longer references it); not cleaned up here.
+
+## Links
+
+- PR: <https://github.com/kaya-go/kaya/pull/116>
+- Precedes: [2026-05-23 Linux model download + glibc](2026-05-23-linux-model-download-and-glibc.md) (deferred this follow-up)
+- Related: [2026-05-04 AI analysis: MCTS-first, unified queue](2026-05-04-ai-analysis-mcts-first.md)

--- a/specs/README.md
+++ b/specs/README.md
@@ -26,15 +26,17 @@ link forward to the replacement. Don't delete history.
 
 ## Index
 
-| Date       | Title                                                                                                   | Status    |
-| ---------- | ------------------------------------------------------------------------------------------------------- | --------- |
-| 2025-12-13 | [Tauri auto-updater setup](2025-12-13-tauri-updater-setup.md)                                           | reference |
-| 2025-12-13 | [Mobile/tablet responsive rollout](2025-12-13-mobile-responsive-rollout.md)                             | shipped   |
-| 2026-01-02 | [Game performance report — rank+probability classifier](2026-01-02-game-performance-report.md)          | shipped   |
-| 2026-02-24 | [AI inference benchmarks on AMD Ryzen 8060S](2026-02-24-ai-inference-benchmarks-amd.md)                 | reference |
-| 2026-02-28 | [WebGPU op decomposition + graph capture](2026-02-28-webgpu-op-decomposition.md)                        | shipped   |
-| 2026-02-28 | [PyTorch sidecar for Linux GPU](2026-02-28-pytorch-sidecar-rocm.md)                                     | shipped   |
-| 2026-05-03 | [CoreML EP falls back to CPU on KataGo b28](2026-05-03-coreml-ep-falls-back-to-cpu.md)                  | reference |
-| 2026-05-03 | [WebGPU unavailable in Tauri webview on macOS/Linux](2026-05-03-webgpu-unavailable-in-tauri-webview.md) | reference |
-| 2026-05-03 | [Native ONNX engine: single session, dynamic axes](2026-05-03-onnx-engine-single-session.md)            | shipped   |
-| 2026-05-04 | [AI analysis: MCTS-first, painless setup, unified queue](2026-05-04-ai-analysis-mcts-first.md)          | shipped   |
+| Date       | Title                                                                                                       | Status    |
+| ---------- | ----------------------------------------------------------------------------------------------------------- | --------- |
+| 2025-12-13 | [Tauri auto-updater setup](2025-12-13-tauri-updater-setup.md)                                               | reference |
+| 2025-12-13 | [Mobile/tablet responsive rollout](2025-12-13-mobile-responsive-rollout.md)                                 | shipped   |
+| 2026-01-02 | [Game performance report — rank+probability classifier](2026-01-02-game-performance-report.md)              | shipped   |
+| 2026-02-24 | [AI inference benchmarks on AMD Ryzen 8060S](2026-02-24-ai-inference-benchmarks-amd.md)                     | reference |
+| 2026-02-28 | [WebGPU op decomposition + graph capture](2026-02-28-webgpu-op-decomposition.md)                            | shipped   |
+| 2026-02-28 | [PyTorch sidecar for Linux GPU](2026-02-28-pytorch-sidecar-rocm.md)                                         | shipped   |
+| 2026-05-03 | [CoreML EP falls back to CPU on KataGo b28](2026-05-03-coreml-ep-falls-back-to-cpu.md)                      | reference |
+| 2026-05-03 | [WebGPU unavailable in Tauri webview on macOS/Linux](2026-05-03-webgpu-unavailable-in-tauri-webview.md)     | reference |
+| 2026-05-03 | [Native ONNX engine: single session, dynamic axes](2026-05-03-onnx-engine-single-session.md)                | shipped   |
+| 2026-05-04 | [AI analysis: MCTS-first, painless setup, unified queue](2026-05-04-ai-analysis-mcts-first.md)              | shipped   |
+| 2026-05-23 | [Linux: model download fix and glibc compatibility](2026-05-23-linux-model-download-and-glibc.md)           | shipped   |
+| 2026-06-09 | [Skip the eager JS-heap model copy on the native desktop path](2026-06-09-lazy-model-buffer-native-path.md) | shipped   |


### PR DESCRIPTION
## Summary

- Initialize desktop native / PyTorch AI engines from the cached model file path when available
- Avoid reading the full ONNX model into JS memory via `onnx_read_model_bytes`
- Keep `ArrayBuffer` loading for WebGPU / WASM and cache-miss scenarios
- Allow the engine chain to pass `modelPath` through to desktop backends

## Why

Desktop model loading previously copied the full cached ONNX file through Tauri IPC into the WebView before the native engine loaded the same model from disk. For 140MB-280MB models, that extra copy can put enough pressure on memory and the UI thread to cause a white screen.

## Verification

- `bun run build:packages`
- `bun --filter @kaya/ui type-check`
- `git diff --check`
- Started the local Tauri dev app successfully