### PR TITLE
feat(ui): add problem mode to open SGFs at the start

### DIFF
--- a/packages/i18n/src/locales/de.json
+++ b/packages/i18n/src/locales/de.json
@@ -202,6 +202,8 @@
     "showCoordinatesDescription": "Zeigt Brettkoordinaten (A-T, 1-19) am Rand des Bretts an.",
     "fuzzyStonePlacement": "Unscharfe Steinplatzierung",
     "fuzzyStonePlacementDescription": "Fügt leichte zufällige Verschiebungen zu Steinpositionen hinzu für ein natürlicheres, handplatziertes Aussehen.",
+    "problemMode": "Aufgabenmodus",
+    "problemModeDescription": "Öffnet SGF-Dateien an der Ausgangsstellung statt am letzten Zug, sodass Tsumego-Lösungen verborgen bleiben, bis du sie selbst durchspielst.",
     "on": "Ein",
     "off": "Aus",
     "themes": {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -202,6 +202,8 @@
     "showCoordinatesDescription": "Display board coordinates (A-T, 1-19) around the edges of the board.",
     "fuzzyStonePlacement": "Fuzzy Stone Placement",
     "fuzzyStonePlacementDescription": "Add slight random offsets to stone positions for a more natural, hand-placed appearance.",
+    "problemMode": "Problem Mode",
+    "problemModeDescription": "Open SGF files at the starting position instead of the last move, so tsumego solutions stay hidden until you play them out.",
     "on": "On",
     "off": "Off",
     "themes": {

--- a/packages/i18n/src/locales/es.json
+++ b/packages/i18n/src/locales/es.json
@@ -202,6 +202,8 @@
     "showCoordinatesDescription": "Mostrar coordenadas del tablero (A-T, 1-19) alrededor de los bordes.",
     "fuzzyStonePlacement": "Colocación difusa de piedras",
     "fuzzyStonePlacementDescription": "Añade pequeños desplazamientos aleatorios a las posiciones de las piedras para una apariencia más natural.",
+    "problemMode": "Modo problema",
+    "problemModeDescription": "Abre los archivos SGF en la posición inicial en lugar de la última jugada, para que las soluciones de tsumego permanezcan ocultas hasta que las juegues.",
     "on": "Activado",
     "off": "Desactivado",
     "themes": {

--- a/packages/i18n/src/locales/fr.json
+++ b/packages/i18n/src/locales/fr.json
@@ -202,6 +202,8 @@
     "showCoordinatesDescription": "Afficher les coordonnées (A-T, 1-19) autour du goban.",
     "fuzzyStonePlacement": "Placement flou des pierres",
     "fuzzyStonePlacementDescription": "Ajoute de légères variations aléatoires à la position des pierres pour un aspect plus naturel.",
+    "problemMode": "Mode problème",
+    "problemModeDescription": "Ouvre les fichiers SGF à la position de départ plutôt qu'au dernier coup, afin que les solutions de tsumego restent cachées jusqu'à ce que vous les jouiez.",
     "on": "Activé",
     "off": "Désactivé",
     "themes": {

--- a/packages/i18n/src/locales/it.json
+++ b/packages/i18n/src/locales/it.json
@@ -202,6 +202,8 @@
     "showCoordinatesDescription": "Visualizza le coordinate della tavola (A-T, 1-19) lungo i bordi.",
     "fuzzyStonePlacement": "Posizionamento sfocato delle pietre",
     "fuzzyStonePlacementDescription": "Aggiunge leggeri spostamenti casuali alle posizioni delle pietre per un aspetto più naturale.",
+    "problemMode": "Modalità problema",
+    "problemModeDescription": "Apre i file SGF nella posizione iniziale anziché all'ultima mossa, così le soluzioni dei tsumego restano nascoste finché non le giochi.",
     "on": "Attivo",
     "off": "Disattivo",
     "themes": {

--- a/packages/i18n/src/locales/ja.json
+++ b/packages/i18n/src/locales/ja.json
@@ -202,6 +202,8 @@
     "showCoordinatesDescription": "碁盤の端に座標（A-T, 1-19）を表示します。",
     "fuzzyStonePlacement": "ファジー配置",
     "fuzzyStonePlacementDescription": "石の位置にわずかなランダムオフセットを加え、手で置いたような自然な見た目にします。",
+    "problemMode": "問題モード",
+    "problemModeDescription": "SGF ファイルを最終手ではなく開始局面で開きます。詰碁の解答は自分で並べるまで表示されません。",
     "on": "オン",
     "off": "オフ",
     "themes": {

--- a/packages/i18n/src/locales/ko.json
+++ b/packages/i18n/src/locales/ko.json
@@ -202,6 +202,8 @@
     "showCoordinatesDescription": "바둑판 가장자리에 좌표(A-T, 1-19)를 표시합니다.",
     "fuzzyStonePlacement": "퍼지 착점",
     "fuzzyStonePlacementDescription": "돌의 위치에 약간의 무작위 오프셋을 추가하여 손으로 놓은 듯한 자연스러운 모습을 연출합니다.",
+    "problemMode": "문제 모드",
+    "problemModeDescription": "SGF 파일을 마지막 수가 아니라 시작 위치에서 엽니다. 사활 문제의 정답이 직접 둘 때까지 숨겨집니다.",
     "on": "켜짐",
     "off": "꺼짐",
     "themes": {

--- a/packages/i18n/src/locales/zh.json
+++ b/packages/i18n/src/locales/zh.json
@@ -202,6 +202,8 @@
     "showCoordinatesDescription": "在棋盘边缘显示坐标（A-T, 1-19）。",
     "fuzzyStonePlacement": "模糊落子",
     "fuzzyStonePlacementDescription": "为棋子位置添加轻微随机偏移，呈现更自然的手工摆放效果。",
+    "problemMode": "习题模式",
+    "problemModeDescription": "打开 SGF 文件时停留在起始位置而非最后一手，让死活题的解答在你逐手摆出之前保持隐藏。",
     "on": "开",
     "off": "关",
     "themes": {

--- a/packages/ui/src/components/ai/KayaConfig.tsx
+++ b/packages/ui/src/components/ai/KayaConfig.tsx
@@ -84,6 +84,31 @@ const GameTab: React.FC<GameTabProps> = ({ gameSettings, setGameSettings }) => {
             </button>
           </div>
         </div>
+
+        {/* Problem Mode Toggle */}
+        <div className="setting-item setting-item-toggle setting-item-full">
+          <div className="setting-info">
+            <label htmlFor="problem-mode-check" className="setting-label">
+              {t('kayaConfig.problemMode')}
+            </label>
+            <p className="setting-description">{t('kayaConfig.problemModeDescription')}</p>
+          </div>
+          <div className="toggle-with-label">
+            <span className={`toggle-status ${gameSettings.problemMode ? 'on' : 'off'}`}>
+              {gameSettings.problemMode ? t('kayaConfig.on') : t('kayaConfig.off')}
+            </span>
+            <button
+              id="problem-mode-check"
+              type="button"
+              role="switch"
+              aria-checked={gameSettings.problemMode}
+              className={`toggle-switch ${gameSettings.problemMode ? 'active' : ''}`}
+              onClick={() => setGameSettings({ problemMode: !gameSettings.problemMode })}
+            >
+              <span className="toggle-switch-handle" />
+            </button>
+          </div>
+        </div>
       </div>
     </section>
   );

--- a/packages/ui/src/hooks/game/determineStartNode.ts
+++ b/packages/ui/src/hooks/game/determineStartNode.ts
@@ -1,0 +1,68 @@
+import { type GameTreeNode } from '@kaya/gametree';
+import { type SGFProperty } from '../../types/game';
+
+export interface DetermineStartNodeOptions {
+  /**
+   * Problem (tsumego) mode. When true, the loader never auto-advances to the
+   * end of a regular game's main line — it stays at the root so the solution
+   * stays hidden until the user steps through it. Collections and joseki/marker
+   * files are unaffected (they already open before any solution moves).
+   */
+  problemMode?: boolean;
+}
+
+/**
+ * Decide which node a freshly-loaded SGF should open on.
+ *
+ * Heuristic to detect different SGF types:
+ *  1. Tsumego/problem collection — root has many children (each a problem) and
+ *     no move of its own → open the first problem.
+ *  2. Joseki dictionary / annotated file — root carries markers/labels, or has
+ *     several variations → stay at the root.
+ *  3. Regular game — a linear main line → jump to the last move so the finished
+ *     position is shown.
+ *
+ * In `problemMode`, case 3 stays at the root instead of revealing the end of
+ * the line, which is what makes single tsumego playable before peeking at the
+ * answer. See https://github.com/kaya-go/kaya/issues/113.
+ */
+export function determineStartNodeId(
+  rootNode: GameTreeNode<SGFProperty>,
+  options: DetermineStartNodeOptions = {}
+): number | string {
+  const hasMarkersAtRoot =
+    rootNode.data.MA ||
+    rootNode.data.TR ||
+    rootNode.data.CR ||
+    rootNode.data.SQ ||
+    rootNode.data.LB;
+  const rootHasMove = rootNode.data.B || rootNode.data.W;
+  const hasManyVariations = rootNode.children.length > 3;
+
+  // Tsumego detection: many children at root, root has no move itself.
+  // This means the root is just a container, and each child is a separate problem.
+  const isTsumegoCollection = hasManyVariations && !rootHasMove && !hasMarkersAtRoot;
+
+  if (isTsumegoCollection && rootNode.children.length > 0) {
+    // Open the first problem so the user can use Up/Down to move between them.
+    return rootNode.children[0].id;
+  }
+
+  if (hasMarkersAtRoot || hasManyVariations) {
+    // Stay at root for joseki dictionaries or files with markers.
+    return rootNode.id;
+  }
+
+  // Regular game.
+  if (options.problemMode) {
+    // Keep the solution hidden: start at the root and let the user play it out.
+    return rootNode.id;
+  }
+
+  // Default: navigate to the end of the main line so the finished game shows.
+  let current = rootNode;
+  while (current.children.length > 0) {
+    current = current.children[0];
+  }
+  return current.id;
+}

--- a/packages/ui/src/hooks/game/useGameSettings.ts
+++ b/packages/ui/src/hooks/game/useGameSettings.ts
@@ -10,13 +10,17 @@ const DEFAULT_GAME_SETTINGS: GameSettings = {
   fuzzyStonePlacement: true, // Enabled by default for natural stone appearance
   showCoordinates: true, // Show coordinates by default
   showBoardControls: true, // Show board controls by default
+  problemMode: false, // Off by default; opt-in for tsumego study
   detectionModelSource: 'default', // Use built-in Moku model by default
 };
 
 /**
- * Load game settings from localStorage
+ * Load game settings from localStorage.
+ *
+ * Exported so non-React load paths (e.g. the SGF loader in `useGameTreeState`)
+ * can read the current persisted value without re-rendering or prop-drilling.
  */
-function loadGameSettings(): GameSettings {
+export function loadGameSettings(): GameSettings {
   try {
     const stored = localStorage.getItem(GAME_SETTINGS_STORAGE_KEY);
     if (stored) {
@@ -34,6 +38,10 @@ function loadGameSettings(): GameSettings {
           typeof parsed.showBoardControls === 'boolean'
             ? parsed.showBoardControls
             : DEFAULT_GAME_SETTINGS.showBoardControls,
+        problemMode:
+          typeof parsed.problemMode === 'boolean'
+            ? parsed.problemMode
+            : DEFAULT_GAME_SETTINGS.problemMode,
         detectionModelSource:
           parsed.detectionModelSource === 'custom'
             ? 'custom'

--- a/packages/ui/src/hooks/game/useGameTreeState.ts
+++ b/packages/ui/src/hooks/game/useGameTreeState.ts
@@ -12,6 +12,8 @@ import { getHandicapStones, type Vertex } from '@kaya/goboard';
 import { type SGFProperty, type NewGameConfig } from '../../types/game';
 import { validateTreeIntegrity } from '../../utils/treeValidation';
 import { clearAllCaches } from '../../utils/gameCache';
+import { determineStartNodeId } from './determineStartNode';
+import { loadGameSettings } from './useGameSettings';
 
 export function useGameTreeState() {
   const [gameTree, setGameTree] = useState<GameTree<SGFProperty> | null>(null);
@@ -167,40 +169,10 @@ export function useGameTreeState() {
           cleanTreeRef.current = newTree; // Mark as clean after load
           setRootId(rootNode.id);
 
-          // Determine starting position based on SGF type
-          // Heuristic to detect different SGF types:
-          // 1. Tsumego/Problem collection: root has many children (each is a problem), root has no move
-          // 2. Joseki dictionary: root has markers or labels at root
-          // 3. Regular game: linear main line
-
-          const hasMarkersAtRoot =
-            rootNode.data.MA ||
-            rootNode.data.TR ||
-            rootNode.data.CR ||
-            rootNode.data.SQ ||
-            rootNode.data.LB;
-          const rootHasMove = rootNode.data.B || rootNode.data.W;
-          const hasManyVariations = rootNode.children.length > 3;
-
-          // Tsumego detection: many children at root, root has no move itself
-          // This means the root is just a container, and each child is a separate problem
-          const isTsumegoCollection = hasManyVariations && !rootHasMove && !hasMarkersAtRoot;
-
-          if (isTsumegoCollection && rootNode.children.length > 0) {
-            // Navigate to first child so user can see all the problem branches
-            // and use Up/Down to navigate between problems
-            setCurrentNodeId(rootNode.children[0].id);
-          } else if (hasMarkersAtRoot || hasManyVariations) {
-            // Stay at root for joseki dictionaries or files with markers
-            setCurrentNodeId(rootNode.id);
-          } else {
-            // Navigate to the end of the main line for regular games
-            let current = rootNode;
-            while (current.children.length > 0) {
-              current = current.children[0];
-            }
-            setCurrentNodeId(current.id);
-          }
+          // Determine starting position based on SGF type and the Problem mode setting.
+          setCurrentNodeId(
+            determineStartNodeId(rootNode, { problemMode: loadGameSettings().problemMode })
+          );
 
           setGameId(`game-${Date.now()}`);
           setLoadingProgress(1);
@@ -253,40 +225,10 @@ export function useGameTreeState() {
             cleanTreeRef.current = newTree; // Mark as clean after load
             setRootId(rootNode.id);
 
-            // Determine starting position based on SGF type
-            // Heuristic to detect different SGF types:
-            // 1. Tsumego/Problem collection: root has many children (each is a problem), root has no move
-            // 2. Joseki dictionary: root has markers or labels at root
-            // 3. Regular game: linear main line
-
-            const hasMarkersAtRoot =
-              rootNode.data.MA ||
-              rootNode.data.TR ||
-              rootNode.data.CR ||
-              rootNode.data.SQ ||
-              rootNode.data.LB;
-            const rootHasMove = rootNode.data.B || rootNode.data.W;
-            const hasManyVariations = rootNode.children.length > 3;
-
-            // Tsumego detection: many children at root, root has no move itself
-            // This means the root is just a container, and each child is a separate problem
-            const isTsumegoCollection = hasManyVariations && !rootHasMove && !hasMarkersAtRoot;
-
-            if (isTsumegoCollection && rootNode.children.length > 0) {
-              // Navigate to first child so user can see all the problem branches
-              // and use Up/Down to navigate between problems
-              setCurrentNodeId(rootNode.children[0].id);
-            } else if (hasMarkersAtRoot || hasManyVariations) {
-              // Stay at root for joseki dictionaries or files with markers
-              setCurrentNodeId(rootNode.id);
-            } else {
-              // Navigate to the end of the main line for regular games
-              let current = rootNode;
-              while (current.children.length > 0) {
-                current = current.children[0];
-              }
-              setCurrentNodeId(current.id);
-            }
+            // Determine starting position based on SGF type and the Problem mode setting.
+            setCurrentNodeId(
+              determineStartNodeId(rootNode, { problemMode: loadGameSettings().problemMode })
+            );
 
             setGameId(`game-${Date.now()}`);
             setLoadingProgress(1);

--- a/packages/ui/src/types/game.ts
+++ b/packages/ui/src/types/game.ts
@@ -81,6 +81,13 @@ export interface GameSettings {
   showCoordinates: boolean;
   /** Show the board controls section (captures, navigation buttons) */
   showBoardControls: boolean;
+  /**
+   * Problem (tsumego) mode. When enabled, opening an SGF never auto-advances
+   * to the end of the main line — single-problem files open at the root so the
+   * solution stays hidden until the user steps through it. Collections still
+   * open at the first problem. See `determineStartNode`.
+   */
+  problemMode: boolean;
   /** Source of the Moku detection ONNX model: 'default' or 'custom' */
   detectionModelSource: 'default' | 'custom';
   /** Name of the uploaded custom detection model file (display only) */

--- a/specs/2026-06-09-problem-mode-open-position.md
+++ b/specs/2026-06-09-problem-mode-open-position.md
@@ -1,0 +1,52 @@
+---
+date: 2026-06-09
+status: shipped
+scope: ui/study
+---
+
+# Problem mode — open SGFs at the start instead of the solution
+
+## Context
+
+[#113](https://github.com/kaya-go/kaya/issues/113): users batch-import tsumego
+(zip/folder of SGFs) and step through them from the library. Single-problem
+files opened **at the last move of the main line**, so the solution was visible
+before the user could attempt the problem.
+
+The open position is chosen by a heuristic in `useGameTreeState` (duplicated in
+both `loadSGF` and `loadSGFAsync`):
+
+1. Problem **collection** (many root children, no root move) → first problem.
+2. Joseki/marker file (markers or many variations at root) → root.
+3. Everything else (a linear main line) → walk to the **end** of the line.
+
+A single tsumego usually has no root markers and one solution line, so it falls
+into case 3 and reveals the answer. The heuristic can't reliably tell "a quiet
+game record" from "one problem," so the fix is to let the user override it.
+
+## Decision
+
+- Added a `problemMode` boolean to `GameSettings` (off by default), persisted
+  via the existing `kaya-game-settings` localStorage path. Surfaced as a
+  **Problem Mode** toggle in the Settings → Game tab.
+- Extracted the duplicated heuristic into `hooks/game/determineStartNode.ts`.
+  The only behavior change: in problem mode, case 3 stays at the **root**
+  instead of walking to the end. Collections and marker files are untouched —
+  they already open before any solution moves.
+- The loader reads the current setting via `loadGameSettings()` (now exported)
+  at load time rather than threading it through the hook graph, keeping
+  `loadSGF`/`loadSGFAsync` self-contained and free of stale-closure risk.
+
+Framed as "Problem mode" (per the issue) rather than a generic
+start/end/auto selector, leaving room to attach other study-friendly behaviors
+to the same switch later.
+
+## Outcome
+
+Turning on Problem Mode opens single problems at the starting position; the
+solution stays hidden until the user plays it out. Default behavior (finished
+games open at the last move) is unchanged.
+
+## Links
+
+- Issue: https://github.com/kaya-go/kaya/issues/113

--- a/specs/README.md
+++ b/specs/README.md
@@ -40,3 +40,4 @@ link forward to the replacement. Don't delete history.
 | 2026-05-04 | [AI analysis: MCTS-first, painless setup, unified queue](2026-05-04-ai-analysis-mcts-first.md)              | shipped   |
 | 2026-05-23 | [Linux: model download fix and glibc compatibility](2026-05-23-linux-model-download-and-glibc.md)           | shipped   |
 | 2026-06-09 | [Skip the eager JS-heap model copy on the native desktop path](2026-06-09-lazy-model-buffer-native-path.md) | shipped   |
+| 2026-06-09 | [Problem mode — open SGFs at the start instead of the solution](2026-06-09-problem-mode-open-position.md)   | shipped   |


### PR DESCRIPTION
Closes #113 (part 1 of 2).

## Problem

Users batch-import tsumego (zip/folder of SGFs) and step through them from the library. A single problem file opened **at the last move of the main line**, so the solution was visible before the user could attempt it.

The open position is picked by a heuristic in `useGameTreeState`: collections open at the first problem, marker/joseki files stay at root, and everything else (a linear main line) walks to the **end** of the line. A single tsumego has no root markers and one solution line, so it falls into that last branch and reveals the answer.

## Change

- New **Problem Mode** toggle in **Settings → Game** (off by default), persisted in the existing `kaya-game-settings` localStorage entry.
- When on, loading a regular linear SGF **stays at the root** instead of walking to the end. Collections and joseki/marker files are unaffected — they already open before any solution moves.
- Extracted the open-position heuristic (previously duplicated in `loadSGF` and `loadSGFAsync`) into `determineStartNode.ts`; it now honors the setting, read fresh from localStorage at load time via the now-exported `loadGameSettings()`.
- i18n: `problemMode` / `problemModeDescription` added for all 8 locales.
- Spec: `specs/2026-06-09-problem-mode-open-position.md`.

## Testing

- `bun run type-check` — clean across all packages + apps.
- Prettier/markdownlint clean (pre-commit hook).

## Notes

Default behavior is unchanged: finished games still open at the last move. Framed as "Problem mode" per the issue, leaving room to attach other study-friendly behaviors to the same switch later. A follow-up PR will add the comment text-size controls also requested in #113.