### PR TITLE
feat(ui): add text-size controls to the comment panel

### DIFF
--- a/packages/i18n/src/locales/de.json
+++ b/packages/i18n/src/locales/de.json
@@ -396,6 +396,8 @@
     "enterHint": "Enter zum Speichern • Shift+Enter für neue Zeile • Esc zum Abbrechen",
     "hint": "Tipp: Markdown zur Formatierung verwenden. Strg/Cmd+S zum Speichern, Esc zum Abbrechen.",
     "editComment": "Kommentar bearbeiten",
+    "increaseTextSize": "Kommentartext vergrößern",
+    "decreaseTextSize": "Kommentartext verkleinern",
     "save": "Speichern",
     "cancel": "Abbrechen",
     "saveShortcut": "Speichern (Cmd/Strg+S)",

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -399,6 +399,8 @@
     "enterHint": "Enter to save • Shift+Enter for new line • Esc to cancel",
     "hint": "Tip: Use markdown for formatting. Ctrl/Cmd+S to save, Esc to cancel.",
     "editComment": "Edit comment",
+    "increaseTextSize": "Increase comment text size",
+    "decreaseTextSize": "Decrease comment text size",
     "save": "Save",
     "cancel": "Cancel",
     "saveShortcut": "Save (Cmd/Ctrl+S)",

--- a/packages/i18n/src/locales/es.json
+++ b/packages/i18n/src/locales/es.json
@@ -396,6 +396,8 @@
     "enterHint": "Enter para guardar • Shift+Enter para nueva línea • Esc para cancelar",
     "hint": "Consejo: Usa markdown para formatear. Ctrl/Cmd+S para guardar, Esc para cancelar.",
     "editComment": "Editar comentario",
+    "increaseTextSize": "Aumentar el tamaño del texto",
+    "decreaseTextSize": "Reducir el tamaño del texto",
     "save": "Guardar",
     "cancel": "Cancelar",
     "saveShortcut": "Guardar (Cmd/Ctrl+S)",

--- a/packages/i18n/src/locales/fr.json
+++ b/packages/i18n/src/locales/fr.json
@@ -396,6 +396,8 @@
     "enterHint": "Entrée pour sauvegarder • Maj+Entrée pour nouvelle ligne • Échap pour annuler",
     "hint": "Astuce : Utilisez le markdown. Ctrl/Cmd+S pour sauver, Échap pour annuler.",
     "editComment": "Éditer le commentaire",
+    "increaseTextSize": "Agrandir le texte du commentaire",
+    "decreaseTextSize": "Réduire le texte du commentaire",
     "save": "Sauver",
     "cancel": "Annuler",
     "saveShortcut": "Sauver (Cmd/Ctrl+S)",

--- a/packages/i18n/src/locales/it.json
+++ b/packages/i18n/src/locales/it.json
@@ -396,6 +396,8 @@
     "enterHint": "Invio per salvare • Shift+Invio per nuova riga • Esc per annullare",
     "hint": "Suggerimento: Usa markdown per formattare. Ctrl/Cmd+S per salvare, Esc per annullare.",
     "editComment": "Modifica commento",
+    "increaseTextSize": "Aumenta la dimensione del testo",
+    "decreaseTextSize": "Riduci la dimensione del testo",
     "save": "Salva",
     "cancel": "Annulla",
     "saveShortcut": "Salva (Cmd/Ctrl+S)",

--- a/packages/i18n/src/locales/ja.json
+++ b/packages/i18n/src/locales/ja.json
@@ -399,6 +399,8 @@
     "enterHint": "Enterで保存 • Shift+Enterで改行 • Escでキャンセル",
     "hint": "ヒント: markdownで書式設定可能。Ctrl/Cmd+Sで保存、Escでキャンセル。",
     "editComment": "コメントを編集",
+    "increaseTextSize": "コメントの文字を大きく",
+    "decreaseTextSize": "コメントの文字を小さく",
     "save": "保存",
     "cancel": "キャンセル",
     "saveShortcut": "保存 (Cmd/Ctrl+S)",

--- a/packages/i18n/src/locales/ko.json
+++ b/packages/i18n/src/locales/ko.json
@@ -399,6 +399,8 @@
     "enterHint": "Enter로 저장 • Shift+Enter로 줄 바꿈 • Esc로 취소",
     "hint": "힌트: 마크다운으로 서식 지정 가능. Ctrl/Cmd+S로 저장, Esc로 취소.",
     "editComment": "댓글 편집",
+    "increaseTextSize": "댓글 글자 크게",
+    "decreaseTextSize": "댓글 글자 작게",
     "save": "저장",
     "cancel": "취소",
     "saveShortcut": "저장 (Cmd/Ctrl+S)",

--- a/packages/i18n/src/locales/zh.json
+++ b/packages/i18n/src/locales/zh.json
@@ -399,6 +399,8 @@
     "enterHint": "Enter 保存 • Shift+Enter 换行 • Esc 取消",
     "hint": "提示：使用 markdown 格式化。Ctrl/Cmd+S 保存，Esc 取消。",
     "editComment": "编辑评论",
+    "increaseTextSize": "增大评论文字",
+    "decreaseTextSize": "减小评论文字",
     "save": "保存",
     "cancel": "取消",
     "saveShortcut": "保存 (Cmd/Ctrl+S)",

--- a/packages/ui/src/components/editors/CommentEditor.css
+++ b/packages/ui/src/components/editors/CommentEditor.css
@@ -48,6 +48,36 @@
   color: var(--accent-foreground);
 }
 
+.comment-fontsize-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.125rem;
+}
+
+.comment-fontsize-button {
+  padding: 0.2rem 0.4rem;
+  min-width: 1.6rem;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--muted-foreground);
+  font-size: 0.8rem;
+  font-weight: 600;
+  line-height: 1;
+  transition: all 0.2s;
+}
+
+.comment-fontsize-button:hover:not(:disabled) {
+  background: var(--accent);
+  color: var(--accent-foreground);
+}
+
+.comment-fontsize-button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
 .comment-save-button,
 .comment-cancel-button {
   padding: 0.35rem 0.75rem;
@@ -129,6 +159,8 @@
   -webkit-user-select: text;
   flex: 1;
   min-height: 0;
+  /* Scaled by the comment text-size control (A- / A+); headings use em so they scale too. */
+  font-size: calc(1rem * var(--comment-font-scale, 1));
 }
 
 .comment-markdown p {
@@ -155,15 +187,15 @@
 }
 
 .comment-markdown h1 {
-  font-size: 1.5rem;
+  font-size: 1.5em;
 }
 
 .comment-markdown h2 {
-  font-size: 1.3rem;
+  font-size: 1.3em;
 }
 
 .comment-markdown h3 {
-  font-size: 1.1rem;
+  font-size: 1.1em;
 }
 
 .comment-markdown p {
@@ -257,7 +289,7 @@
   background: var(--background);
   color: var(--text);
   font-family: 'Monaco', 'Courier New', monospace;
-  font-size: 0.9rem;
+  font-size: calc(0.9rem * var(--comment-font-scale, 1));
   line-height: 1.6;
   resize: none;
   outline: none;

--- a/packages/ui/src/components/editors/CommentEditor.tsx
+++ b/packages/ui/src/components/editors/CommentEditor.tsx
@@ -10,6 +10,12 @@ import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useGameTreeBoard, useGameTreeEdit } from '../../contexts/GameTreeContext';
+import {
+  COMMENT_FONT_SCALE_MAX,
+  COMMENT_FONT_SCALE_MIN,
+  COMMENT_FONT_SCALE_STEP,
+  clampCommentFontScale,
+} from '../../utils/commentFontScale';
 import './CommentEditor.css';
 
 // ============================================================================
@@ -26,6 +32,10 @@ interface CommentEditorContextValue {
   handleEdit: () => void;
   handleSave: () => void;
   handleCancel: () => void;
+  fontScale: number;
+  adjustFontScale: (delta: number) => void;
+  canIncreaseFont: boolean;
+  canDecreaseFont: boolean;
 }
 
 const CommentEditorContext = createContext<CommentEditorContextValue | null>(null);
@@ -35,11 +45,21 @@ const CommentEditorContext = createContext<CommentEditorContextValue | null>(nul
  * Wrap your app with this to share state between CommentHeaderActions and CommentEditor.
  */
 export const CommentEditorProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { currentNode, moveNumber } = useGameTreeBoard();
+  const { currentNode, moveNumber, gameSettings, setGameSettings } = useGameTreeBoard();
   const { setNodeComment: updateComment } = useGameTreeEdit();
   const [isEditing, setIsEditing] = useState(false);
   const [editText, setEditText] = useState('');
   const prevNodeIdRef = useRef<string | number | null>(null);
+
+  const fontScale = gameSettings.commentFontScale;
+  const adjustFontScale = useCallback(
+    (delta: number) => {
+      setGameSettings({ commentFontScale: clampCommentFontScale(fontScale + delta) });
+    },
+    [fontScale, setGameSettings]
+  );
+  const canIncreaseFont = fontScale < COMMENT_FONT_SCALE_MAX;
+  const canDecreaseFont = fontScale > COMMENT_FONT_SCALE_MIN;
 
   const currentComment = currentNode?.data.C?.[0] || '';
   const currentNodeId = currentNode?.id ?? null;
@@ -85,6 +105,10 @@ export const CommentEditorProvider: React.FC<{ children: React.ReactNode }> = ({
     handleEdit,
     handleSave,
     handleCancel,
+    fontScale,
+    adjustFontScale,
+    canIncreaseFont,
+    canDecreaseFont,
   };
 
   return <CommentEditorContext.Provider value={value}>{children}</CommentEditorContext.Provider>;
@@ -112,12 +136,45 @@ export const useCommentEditorState = (): CommentEditorContextValue => {
  */
 export const CommentHeaderActions: React.FC = () => {
   const { t } = useTranslation();
-  const { moveNumber, isEditing, handleEdit, handleSave, handleCancel } = useCommentEditorState();
+  const {
+    moveNumber,
+    isEditing,
+    handleEdit,
+    handleSave,
+    handleCancel,
+    adjustFontScale,
+    canIncreaseFont,
+    canDecreaseFont,
+  } = useCommentEditorState();
 
   return (
     <>
       {moveNumber > 0 && (
         <span className="move-number">{t('comment.move', { number: moveNumber })}</span>
+      )}
+      {!isEditing && (
+        <div className="comment-fontsize-controls">
+          <button
+            type="button"
+            onClick={() => adjustFontScale(-COMMENT_FONT_SCALE_STEP)}
+            disabled={!canDecreaseFont}
+            className="comment-fontsize-button"
+            title={t('comment.decreaseTextSize')}
+            aria-label={t('comment.decreaseTextSize')}
+          >
+            A&minus;
+          </button>
+          <button
+            type="button"
+            onClick={() => adjustFontScale(COMMENT_FONT_SCALE_STEP)}
+            disabled={!canIncreaseFont}
+            className="comment-fontsize-button"
+            title={t('comment.increaseTextSize')}
+            aria-label={t('comment.increaseTextSize')}
+          >
+            A+
+          </button>
+        </div>
       )}
       {!isEditing && (
         <button
@@ -181,9 +238,13 @@ export const CommentEditor: React.FC = () => {
     handleEdit,
     handleSave,
     handleCancel,
+    fontScale,
   } = useCommentEditorState();
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Drive comment text size from the persisted scale via a CSS variable.
+  const fontScaleStyle = { '--comment-font-scale': fontScale } as React.CSSProperties;
 
   // Focus textarea when entering edit mode
   useEffect(() => {
@@ -226,7 +287,10 @@ export const CommentEditor: React.FC = () => {
   }
 
   return (
-    <div className={`comment-editor ${isEditing ? 'comment-editor--editing' : ''}`}>
+    <div
+      className={`comment-editor ${isEditing ? 'comment-editor--editing' : ''}`}
+      style={fontScaleStyle}
+    >
       {isEditing ? (
         <div className="comment-editor-container">
           <textarea

--- a/packages/ui/src/hooks/game/useGameSettings.ts
+++ b/packages/ui/src/hooks/game/useGameSettings.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { type GameSettings } from '../../types/game';
+import { COMMENT_FONT_SCALE_DEFAULT, clampCommentFontScale } from '../../utils/commentFontScale';
 
 const GAME_SETTINGS_STORAGE_KEY = 'kaya-game-settings';
 
@@ -10,6 +11,7 @@ const DEFAULT_GAME_SETTINGS: GameSettings = {
   fuzzyStonePlacement: true, // Enabled by default for natural stone appearance
   showCoordinates: true, // Show coordinates by default
   showBoardControls: true, // Show board controls by default
+  commentFontScale: COMMENT_FONT_SCALE_DEFAULT, // Default comment text size
   detectionModelSource: 'default', // Use built-in Moku model by default
 };
 
@@ -34,6 +36,10 @@ function loadGameSettings(): GameSettings {
           typeof parsed.showBoardControls === 'boolean'
             ? parsed.showBoardControls
             : DEFAULT_GAME_SETTINGS.showBoardControls,
+        commentFontScale:
+          typeof parsed.commentFontScale === 'number'
+            ? clampCommentFontScale(parsed.commentFontScale)
+            : DEFAULT_GAME_SETTINGS.commentFontScale,
         detectionModelSource:
           parsed.detectionModelSource === 'custom'
             ? 'custom'

--- a/packages/ui/src/types/game.ts
+++ b/packages/ui/src/types/game.ts
@@ -81,6 +81,11 @@ export interface GameSettings {
   showCoordinates: boolean;
   /** Show the board controls section (captures, navigation buttons) */
   showBoardControls: boolean;
+  /**
+   * Text-size multiplier for the move comment panel (1 = default).
+   * Clamped to [COMMENT_FONT_SCALE_MIN, COMMENT_FONT_SCALE_MAX].
+   */
+  commentFontScale: number;
   /** Source of the Moku detection ONNX model: 'default' or 'custom' */
   detectionModelSource: 'default' | 'custom';
   /** Name of the uploaded custom detection model file (display only) */

--- a/packages/ui/src/utils/commentFontScale.ts
+++ b/packages/ui/src/utils/commentFontScale.ts
@@ -1,0 +1,17 @@
+/**
+ * Bounds and helpers for the move-comment text-size control.
+ *
+ * The scale is a plain multiplier applied to the comment panel's base font
+ * size via the `--comment-font-scale` CSS variable. 1 is the default size.
+ */
+export const COMMENT_FONT_SCALE_MIN = 0.8;
+export const COMMENT_FONT_SCALE_MAX = 1.6;
+export const COMMENT_FONT_SCALE_STEP = 0.1;
+export const COMMENT_FONT_SCALE_DEFAULT = 1;
+
+/** Clamp a scale into the supported range and round to avoid float drift. */
+export function clampCommentFontScale(scale: number): number {
+  if (!Number.isFinite(scale)) return COMMENT_FONT_SCALE_DEFAULT;
+  const clamped = Math.min(COMMENT_FONT_SCALE_MAX, Math.max(COMMENT_FONT_SCALE_MIN, scale));
+  return Math.round(clamped * 100) / 100;
+}


### PR DESCRIPTION
Closes #113 (part 2 of 2).

## What

Adds **A− / A+** buttons next to the comment edit button to scale the move-comment text, as requested in #113.

- The multiplier is persisted in game settings (`commentFontScale`, clamped **0.8–1.6**, step 0.1), so it survives reloads and applies across all comments.
- Applied via a `--comment-font-scale` CSS variable on the comment editor root. The markdown body and the edit textarea scale together; headings were switched from `rem` to `em` so they scale proportionally.
- Buttons disable at the min/max bound.
- i18n: `comment.increaseTextSize` / `comment.decreaseTextSize` added for all 8 locales (used for both tooltip and `aria-label`).

## Testing

- `bun run type-check` — clean across all packages + apps.
- Prettier/markdownlint clean (pre-commit hook).

## Notes

Pairs with #117 (problem mode), the other half of #113. Independent of it — branched from `main`, so the two can merge in any order (they both touch `GameSettings`/`useGameSettings`, so expect a trivial conflict in whichever merges second).