### PR TITLE
fix(web): request persistent storage to avoid model/settings eviction

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,6 +1,11 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { ThemeProvider, BoardThemeProvider, I18nProvider } from '@kaya/ui';
+import {
+  ThemeProvider,
+  BoardThemeProvider,
+  I18nProvider,
+  requestPersistentStorage,
+} from '@kaya/ui';
 import App from './App.tsx';
 import '@kaya/ui/dist/styles/ui.css';
 import { registerServiceWorker } from './pwa.ts';
@@ -14,6 +19,10 @@ registerServiceWorker({
     console.log('[PWA] App ready to work offline');
   },
 });
+
+// Ask the browser to keep our storage so downloaded models and settings persist
+// across sessions instead of being evicted (issue #115). No-op outside the web.
+void requestPersistentStorage();
 
 // Suppress benign ResizeObserver warning from react-resizable-panels
 // This is a common timing issue and doesn't affect functionality

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,8 +16,11 @@ desktop, a PWA in the browser. KataGo runs locally — through ONNX Runtime
 ## Design objectives
 
 - **Local-first.** Everything works offline once assets are downloaded.
-  No cloud calls in the hot path. Game files live on disk (desktop) or
-  IndexedDB (web).
+  No cloud calls in the hot path. Game files, settings, and AI models live
+  on disk (desktop) or in IndexedDB/localStorage (web). On web the app
+  requests [persistent storage](../specs/2026-06-09-web-persistent-storage.md)
+  at startup so the browser doesn't evict downloaded models and settings
+  between sessions.
 - **One frontend, two targets.** Web and desktop share a single React tree
   and component library. The differences are platform shims (file save,
   audio, AI engine), not parallel UIs.

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -8,3 +8,5 @@
 export { saveFile, isTauriApp, setTauriSaveAPI, type TauriSaveAPI } from './fileSave';
 
 export { readClipboardText, writeClipboardText, setTauriClipboardAPI } from './clipboard';
+
+export { requestPersistentStorage } from './storage';

--- a/packages/platform/src/storage.ts
+++ b/packages/platform/src/storage.ts
@@ -1,0 +1,50 @@
+/**
+ * Persistent storage management.
+ *
+ * Browsers keep IndexedDB / localStorage as "best-effort" storage by default,
+ * which the browser may evict under storage pressure. Worse, Safari/WebKit ITP
+ * deletes all script-writable storage after 7 days of no interaction with the
+ * site. On the web app this means downloaded ONNX models (tens to hundreds of
+ * MB in IndexedDB) and saved settings silently disappear between sessions, so
+ * users have to re-download / re-point to their model every time (issue #115).
+ *
+ * Requesting persistent storage upgrades the origin so it is exempt from
+ * automatic eviction. The grant is automatic on Chromium for installed /
+ * high-engagement PWAs, prompts on Firefox, and is best-effort on Safari (where
+ * installing to the Home Screen remains the reliable exemption).
+ */
+
+/**
+ * Request persistent storage for the current origin so settings and downloaded
+ * models survive across sessions.
+ *
+ * Safe to call in any environment: it is a guarded no-op when the Storage API
+ * is unavailable (e.g. the Tauri desktop webview, where models are cached on
+ * native disk and are not subject to browser eviction).
+ *
+ * @returns `true` if storage is persistent, `false` if the request was denied
+ * (best-effort), or `null` if the API is unsupported.
+ */
+export async function requestPersistentStorage(): Promise<boolean | null> {
+  if (typeof navigator === 'undefined' || !navigator.storage?.persist) {
+    return null;
+  }
+
+  try {
+    // Already persistent (e.g. granted in a previous session) — don't re-ask.
+    if (await navigator.storage.persisted()) {
+      return true;
+    }
+
+    const granted = await navigator.storage.persist();
+    console.log(
+      granted
+        ? '[storage] Persistent storage granted — settings and models will survive across sessions'
+        : '[storage] Persistent storage denied (best-effort) — the browser may evict data; install the PWA for reliable persistence'
+    );
+    return granted;
+  } catch (error) {
+    console.warn('[storage] Failed to request persistent storage:', error);
+    return null;
+  }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -121,6 +121,7 @@ export { saveFile, isTauriApp, setTauriSaveAPI } from '@kaya/platform';
 export { setTauriClipboardAPI } from '@kaya/platform';
 export type { TauriSaveAPI } from '@kaya/platform';
 export { readClipboardText, writeClipboardText } from '@kaya/platform';
+export { requestPersistentStorage } from '@kaya/platform';
 
 // Hooks
 export { useGameSounds, setSoundInitErrorHandler } from './useGameSounds';

--- a/specs/2026-06-09-web-persistent-storage.md
+++ b/specs/2026-06-09-web-persistent-storage.md
@@ -1,0 +1,63 @@
+---
+date: 2026-06-09
+status: shipped
+scope: web/storage
+---
+
+# Request persistent storage on web
+
+## Context
+
+[Issue #115](https://github.com/kaya-go/kaya/issues/115) reported that on the
+PWA, the downloaded ONNX model had to be re-selected on every session — the user
+asked for an export/import config file to save re-doing setup each time.
+
+Investigation showed the data layer already persists everything it should:
+
+- Settings (AI, game, theme, shortcuts) → `localStorage`.
+- The ONNX model blob, library metadata, and selected-model id → IndexedDB, via
+  [`modelStorage.ts`](../packages/ui/src/services/modelStorage.ts)
+  (`saveModelData` / `loadModelData` round-trip correctly).
+
+So nothing should need re-pointing. The fact that it works for frequent Chromium
+users but not the reporter pointed to **browser storage eviction**, not a reload
+bug. By default IndexedDB/localStorage are "best-effort" storage the browser may
+evict under disk pressure — and Safari/WebKit ITP deletes all script-writable
+storage after 7 days of no interaction with the site (home-screen PWAs excepted).
+Confirmed: `navigator.storage.persist()` was never called anywhere in the repo.
+
+## Decision
+
+Call `navigator.storage.persist()` once at web startup, via a guarded
+`requestPersistentStorage()` helper in
+[`@kaya/platform`](../packages/platform/src/storage.ts), re-exported through
+`@kaya/ui` and invoked from [`apps/web/src/main.tsx`](../apps/web/src/main.tsx).
+It is a no-op when the Storage API is absent (Tauri desktop webview, where models
+are cached on native disk and never evicted), so the call is safe everywhere but
+only wired into the web entry.
+
+**Declined the issue's proposed export/import config file.** It treats the
+symptom, not the cause: without fixing eviction the user would re-import the file
+every session — barely better than re-pointing. It also adds a file format,
+validation, schema migrations, and another control in an already 5-tab settings
+modal, for marginal value (its real use is cross-device sync, a much smaller
+need). Kept as a possible future "settings-only JSON" if multi-device demand
+appears; the large model blob would never belong in such an export — it is
+re-downloadable from the URL already stored in its metadata.
+
+## Learnings
+
+- **Best-effort vs persistent storage is the whole game.** Persistence "working"
+  in dev (frequent Chromium use keeps best-effort storage alive, and engaged /
+  installed PWAs get an automatic grant) masks the problem for occasional users.
+- **Grant behavior differs by browser:** Chromium grants automatically for
+  installed / high-engagement origins, Firefox prompts, Safari is best-effort.
+  `persist()` is the correct standard fix and reliable on Chromium/Firefox, but
+  **not a 100% guarantee on Safari/iOS** — there, installing to the Home Screen
+  is the dependable exemption. Worth saying so when advising users.
+
+## Links
+
+- Issue: https://github.com/kaya-go/kaya/issues/115
+- Helper: [`packages/platform/src/storage.ts`](../packages/platform/src/storage.ts)
+- Model storage: [`packages/ui/src/services/modelStorage.ts`](../packages/ui/src/services/modelStorage.ts)

--- a/specs/README.md
+++ b/specs/README.md
@@ -41,3 +41,4 @@ link forward to the replacement. Don't delete history.
 | 2026-05-23 | [Linux: model download fix and glibc compatibility](2026-05-23-linux-model-download-and-glibc.md)           | shipped   |
 | 2026-06-09 | [Skip the eager JS-heap model copy on the native desktop path](2026-06-09-lazy-model-buffer-native-path.md) | shipped   |
 | 2026-06-09 | [Problem mode — open SGFs at the start instead of the solution](2026-06-09-problem-mode-open-position.md)   | shipped   |
+| 2026-06-09 | [Request persistent storage on web](2026-06-09-web-persistent-storage.md)                                   | shipped   |


### PR DESCRIPTION
## Problem

On the **web app / PWA**, users reported having to re-download or re-point to
their downloaded ONNX model on **every session** ([#115](https://github.com/kaya-go/kaya/issues/115)).

The data layer was not the problem — settings (`localStorage`) and the model
blob + selected-model id (IndexedDB, via `modelStorage.ts`) already round-trip
correctly. The issue is **browser storage eviction**:

- By default IndexedDB/localStorage are *best-effort* storage the browser may
  evict under disk pressure.
- **Safari/WebKit ITP** deletes all script-writable storage after **7 days** of
  no interaction with the site (this is time-based, so it hits even a healthy
  machine). Home-screen PWAs are exempt.

`navigator.storage.persist()` was never called anywhere in the repo, so the
origin was never upgraded to persistent storage. That explains why it works for
frequent Chromium users but not for occasional / Safari users.

## Fix

- New guarded `requestPersistentStorage()` helper in `@kaya/platform`
  (re-exported through `@kaya/ui`), called once at web startup in
  `apps/web/src/main.tsx`.
- It's idempotent (skips if already persisted) and a **no-op** when the Storage
  API is unavailable — e.g. the Tauri desktop webview, where models are cached
  on native disk and never evicted. So desktop is untouched.
- No UI, no new strings, no settings — silent best-effort upgrade with a single
  console log.

Effective on Chromium (auto-grant for installed/engaged PWAs) and Firefox
(prompt). On Safari/iOS it helps but isn't a 100% guarantee — installing to the
Home Screen remains the reliable exemption there; this is called out in the spec
and will be in the issue reply.

## Considered & declined

The issue proposed an **export/import config file**. Declined: it treats the
symptom (users would re-import every session without fixing eviction), adds a
file format + validation + schema migrations + UI clutter, and the large model
blob doesn't belong in an export anyway (it's re-downloadable from its stored
URL). Left as a possible future settings-only JSON if multi-device demand shows up.

## Docs

- New spec: `specs/2026-06-09-web-persistent-storage.md`
- `docs/ARCHITECTURE.md` local-first objective notes the persistent-storage request.

## Test plan

- `bun run build:packages` ✅
- `bun run type-check` ✅ (all 13 packages + web + desktop)
- `bun run test` ✅ (153 pass)
- `bun run format` ✅ clean

Addresses #115.
