### PR TITLE
chore(deps): bump rust minor/patch deps, hold ort at rc.12

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,7 +31,8 @@ updates:
     # binary `download-binaries` fetches. Enabling `cuda` would pull the
     # multi-GB CUDA distribution, and no Linux distribution ships `migraphx`
     # at all, so the bump needs a deliberate migration rather than a lockfile
-    # update. Tracked separately -- drop this ignore once that lands.
+    # update. See specs/2026-08-02-ort-rc13-pinned.md -- drop this ignore once
+    # that migration lands.
     ignore:
       - dependency-name: 'ort'
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,15 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: 'chore(deps)'
+    # `ort` is pinned to 2.0.0-rc.12 on purpose. rc.13 renamed the execution
+    # provider types (CUDAExecutionProvider -> CUDA, ...) and put each one
+    # behind a cargo feature that also selects which prebuilt ONNX Runtime
+    # binary `download-binaries` fetches. Enabling `cuda` would pull the
+    # multi-GB CUDA distribution, and no Linux distribution ships `migraphx`
+    # at all, so the bump needs a deliberate migration rather than a lockfile
+    # update. Tracked separately -- drop this ignore once that lands.
+    ignore:
+      - dependency-name: 'ort'
     groups:
       rust-minor-patch:
         patterns:

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1181,9 +1181,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1196,9 +1196,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1206,15 +1206,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1223,15 +1223,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1240,21 +1240,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4153,9 +4153,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4175,22 +4175,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4206,9 +4206,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -4589,6 +4589,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4857,9 +4868,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-dialog"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+checksum = "b2d3c1dbe38037e7f590cdf2492594d5ceebe031e7bc7e827509b22a999d2940"
 dependencies = [
  "log",
  "raw-window-handle",
@@ -5248,9 +5259,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",

--- a/specs/2026-08-02-ort-rc13-pinned.md
+++ b/specs/2026-08-02-ort-rc13-pinned.md
@@ -1,0 +1,79 @@
+---
+date: 2026-08-02
+status: shipped
+scope: ai/onnx
+---
+
+# ort pinned at 2.0.0-rc.12
+
+## Context
+
+The monthly dependabot `rust-minor-patch` group (#136) bundled six updates for
+`apps/desktop/src-tauri`, one of which was `ort` 2.0.0-rc.12 → rc.13. The PR
+failed both `Desktop App` and `Android Check` with `E0432: unresolved imports`
+against `src/onnx_engine/execution_providers.rs`, blocking the five unrelated
+updates in the same group.
+
+rc.13 is breaking in two ways. The first is cosmetic: the `execution_providers`
+module became `ep` (the old path survives as a re-export), and the provider
+types lost their suffix — `CUDAExecutionProvider` → `CUDA`, and likewise for
+`CoreML`, `DirectML`, `MIGraphX`, `NNAPI`.
+
+The second is not. Each provider now sits behind a cargo feature, and those
+features are forwarded to `ort-sys`, where they select which prebuilt ONNX
+Runtime binary `download-binaries` fetches. `resolve_dist()` hard-errors when
+the requested feature set is not fully covered by some published distribution,
+unless `lax-feature-matching` is enabled. Reading
+`ort-sys-2.0.0-rc.13/build/download/dist.tsv`:
+
+| Target                     | Available distributions                                                  |
+| -------------------------- | ------------------------------------------------------------------------ |
+| `aarch64-apple-darwin`     | `coreml`, `coreml,webgpu`                                                |
+| `x86_64-pc-windows-msvc`   | `directml`, `webgpu`, `nvrtx,directml`, `cuda13,tensorrt,nvrtx,directml` |
+| `x86_64-unknown-linux-gnu` | `none`, `webgpu`, `nvrtx`, `cuda13,tensorrt,nvrtx`                       |
+| `aarch64-linux-android`    | `nnapi`                                                                  |
+
+So `coreml`, `directml` and `nnapi` are free — they match what we already
+download (Android uses `load-dynamic`, so nothing is downloaded there at all).
+But **no Linux distribution ships `migraphx`**, which means enabling it fails
+the build outright; and enabling `cuda` switches Linux and Windows to the
+multi-GB `cuda13,tensorrt,...` distribution that also expects a CUDA runtime.
+
+Under rc.12 none of this came up: any provider could be referenced
+unconditionally and registration was a runtime no-op when that provider was
+absent from the binary. That is precisely what the current Linux code leans on
+— the plain CPU build ships by default and power users point `ORT_DYLIB_PATH`
+at a MIGraphX or CUDA build of ONNX Runtime.
+
+## Decision
+
+Split the group. Apply the five compatible updates (`tauri-plugin-dialog`,
+`serde`, `serde_json`, `tokio`, `futures`) and hold `ort` at rc.12 behind a
+dependabot `ignore`, so the group stops failing every month.
+
+The upgrade is deferred rather than rushed because it forces a product
+decision, not a lockfile edit: whether `Cuda` and `MiGraphX` remain
+user-selectable in `ExecutionProviderPreference`. Keeping them likely means
+turning on `lax-feature-matching` alongside the provider features, so the API
+compiles while the default download stays the plain CPU build and GPU use
+continues through `ORT_DYLIB_PATH` — but that combination needs verifying on
+each target, and CI only runs `cargo check`.
+
+## Learnings
+
+- Grouped dependabot PRs are all-or-nothing. One breaking member holds the
+  whole group hostage, and there is no partial merge — the group has to be
+  reconstructed by hand with `cargo update -p <crate>`.
+- In `ort` rc.13, cargo features are no longer just API gating; for anything
+  using `download-binaries` they are also binary selection. A feature flag that
+  looks free can silently change what gets shipped, or fail the build because
+  no matching distribution was ever published.
+- Worth re-testing during the migration: the CoreML op-coverage limitation
+  recorded in [CoreML EP falls back to CPU on KataGo b28](2026-05-03-coreml-ep-falls-back-to-cpu.md)
+  and noted at `execution_providers.rs:173`. rc.13 may have moved it.
+
+## Links
+
+- Tracking issue: kaya-go/kaya#139
+- Superseded PR: kaya-go/kaya#136 · replacement: kaya-go/kaya#138
+- `ignore` rule and rationale: [.github/dependabot.yml](../.github/dependabot.yml)

--- a/specs/README.md
+++ b/specs/README.md
@@ -42,3 +42,4 @@ link forward to the replacement. Don't delete history.
 | 2026-06-09 | [Skip the eager JS-heap model copy on the native desktop path](2026-06-09-lazy-model-buffer-native-path.md) | shipped   |
 | 2026-06-09 | [Problem mode — open SGFs at the start instead of the solution](2026-06-09-problem-mode-open-position.md)   | shipped   |
 | 2026-06-09 | [Request persistent storage on web](2026-06-09-web-persistent-storage.md)                                   | shipped   |
+| 2026-08-02 | [ort pinned at 2.0.0-rc.12](2026-08-02-ort-rc13-pinned.md)                                                  | shipped   |


### PR DESCRIPTION
Replaces #136, which failed CI.

## What

Applies the five compatible updates from the `rust-minor-patch` group:

| Package | From | To |
| --- | --- | --- |
| tauri-plugin-dialog | 2.7.1 | 2.7.2 |
| serde | 1.0.228 | 1.0.229 |
| serde_json | 1.0.150 | 1.0.151 |
| tokio | 1.52.3 | 1.53.1 |
| futures | 0.3.32 | 0.3.33 |

`ort` stays at `2.0.0-rc.12`.

## Why ort is held back

#136 failed `Desktop App` and `Android Check` with `E0432: unresolved imports`
because rc.13 is a breaking release:

1. **The EP types were renamed.** `execution_providers` became `ep` (the old
   path survives as a re-export), and `CUDAExecutionProvider` / `CoreMLExecutionProvider` /
   `DirectMLExecutionProvider` / `MIGraphXExecutionProvider` / `NNAPIExecutionProvider`
   became `CUDA` / `CoreML` / `DirectML` / `MIGraphX` / `NNAPI`.

2. **Each EP is now behind a cargo feature**, and those same features drive
   which prebuilt binary `download-binaries` fetches. That is the part that
   makes this more than a rename:
   - Enabling `cuda` selects the `cuda13,tensorrt,nvrtx` distribution — a
     multi-GB download that also expects a CUDA runtime. We currently expose a
     `cuda` preference on both Linux and Windows.
   - **No Linux distribution ships `migraphx`.** `ort-sys` errors out when the
     requested feature set is not fully satisfied by some distribution, so
     enabling `migraphx` fails the build outright unless we also turn on
     `lax-feature-matching`.
   - `coreml` (macOS), `directml` (Windows) and `nnapi` (Android) are free —
     they match the distributions already being downloaded.

So the upgrade forces a decision about how CUDA and MIGraphX support are
offered, which does not belong in a dependency bump. Added a dependabot
`ignore` for `ort` so the monthly group stops failing until that migration is
done; the tracking issue has the full findings.

## Verification

`cargo check` passes locally on aarch64-apple-darwin. Full CI covers the other
targets.